### PR TITLE
Fix: BTActionNodes fail instead throwing exceptions enabling fallback/recovery mechanisms in BT trees

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -178,7 +178,7 @@ public:
 
       default:
         RCLCPP_ERROR(
-          node_->get_logger(), "Action %s returned Unknown action status", action_name_.c_str());
+          node_->get_logger(), "Action server \"%s\" returned Unknown action status", action_name_.c_str());
         return BT::NodeStatus::FAILURE;
     }
   }
@@ -194,7 +194,7 @@ public:
       {
         RCLCPP_ERROR(
           node_->get_logger(),
-          "Failed to cancel action server for %s", action_name_.c_str());
+          "Failed to cancel action server \"%s\"", action_name_.c_str());
       }
     }
 
@@ -238,13 +238,16 @@ protected:
     if (rclcpp::spin_until_future_complete(node_, future_goal_handle, server_timeout_) !=
       rclcpp::FutureReturnCode::SUCCESS)
     {
+      RCLCPP_ERROR(
+          node_->get_logger(), "Error sending goal to action server \"%s\" using a timeout of %d milliseconds.",
+            action_name_.c_str(), server_timeout_);
       return BT::NodeStatus::FAILURE;
     }
 
     goal_handle_ = future_goal_handle.get();
     if (!goal_handle_) {
       RCLCPP_ERROR(
-          node_->get_logger(), "Goal was rejected by action server %s", action_name_.c_str());
+          node_->get_logger(), "Goal was rejected by action server \"%s\"", action_name_.c_str());
       return BT::NodeStatus::FAILURE;
     }
     return BT::NodeStatus::SUCCESS;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -138,7 +138,10 @@ public:
       // user defined callback
       on_tick();
 
-      on_new_goal_received();
+      BT::NodeStatus status = on_new_goal_received();
+      if( status == BT::NodeStatus::FAILURE) {
+        return BT::NodeStatus::FAILURE;
+      }
     }
 
     // The following code corresponds to the "RUNNING" loop
@@ -174,7 +177,9 @@ public:
         return on_cancelled();
 
       default:
-        throw std::logic_error("BtActionNode::Tick: invalid status value");
+        RCLCPP_ERROR(
+          node_->get_logger(), "Action %s returned Unknown action status", action_name_.c_str());
+        return BT::NodeStatus::FAILURE;
     }
   }
 
@@ -213,7 +218,7 @@ protected:
   }
 
 
-  void on_new_goal_received()
+  BT::NodeStatus on_new_goal_received()
   {
     goal_result_available_ = false;
     auto send_goal_options = typename rclcpp_action::Client<ActionT>::SendGoalOptions();
@@ -233,13 +238,16 @@ protected:
     if (rclcpp::spin_until_future_complete(node_, future_goal_handle, server_timeout_) !=
       rclcpp::FutureReturnCode::SUCCESS)
     {
-      throw std::runtime_error("send_goal failed");
+      return BT::NodeStatus::FAILURE;
     }
 
     goal_handle_ = future_goal_handle.get();
     if (!goal_handle_) {
-      throw std::runtime_error("Goal was rejected by the action server");
+      RCLCPP_ERROR(
+          node_->get_logger(), "Goal was rejected by action server %s", action_name_.c_str());
+      return BT::NodeStatus::FAILURE;
     }
+    return BT::NodeStatus::SUCCESS;
   }
 
   void increment_recovery_count()


### PR DESCRIPTION
Fixes all the action nodes in BT. Now recovery nodes are able to take a recovery/fallback node if they fail to succeed. Before, the whole bt_naviation node failed.

See for details: https://github.com/ros-planning/navigation2/issues/2376

Test:
- Demo test with actual robot working