### PR TITLE
🔥 removed backward_ros

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(nav2_amcl)
 
-find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_util REQUIRED)
-find_package(backward_ros REQUIRED)
 
 nav2_package()
 

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(std_srvs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(backward_ros REQUIRED)
 
 nav2_package()
 


### PR DESCRIPTION
## Purpose
Some of the CI packages get stuck due to bad dependency management requiring backward_ros.

## Approach
After a talk with @guilyx we have agreed there is no need to use backward_ros and this is the easiest solution to fix multiple CI's.

### Open Questions and Pre-Merge TODOs
N/A

## Dependencies
N/A

## Disclaimers
N/A
 
## Learning
N/A