### PR TITLE
Initial pose status service

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(cmr_msgs REQUIRED)
 
 nav2_package()
 
@@ -60,6 +61,7 @@ set(dependencies
   tf2
   nav2_util
   nav2_msgs
+  cmr_msgs
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -44,6 +44,8 @@
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
 
+#include "cmr_msgs/srv/get_status.hpp"
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wreorder"
@@ -214,6 +216,15 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<std_srvs::srv::Empty::Request> request,
     std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  // Report whether initial pose set or not
+  rclcpp::Service<cmr_msgs::srv::GetStatus>::SharedPtr get_initial_pose_status_srv_;
+  /*
+   * @brief Service callback for sending intial pose status
+   */
+  void getInitialPoseStatusCallback(
+    const std::shared_ptr<cmr_msgs::srv::GetStatus::Request>,
+    std::shared_ptr<cmr_msgs::srv::GetStatus::Response> response);
 
   // Nomotion update control. Used to temporarily let amcl update samples even when no motion occurs
   std::atomic<bool> force_update_{false};

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -554,6 +554,16 @@ AmclNode::nomotionUpdateCallback(
 }
 
 void
+AmclNode::getInitialPoseStatusCallback(
+  const std::shared_ptr<cmr_msgs::srv::GetStatus::Request>,
+  std::shared_ptr<cmr_msgs::srv::GetStatus::Response> response)
+{
+  response->status = response->STATUS_NOT_READY;
+
+  if(initial_pose_is_known_) response->status = response->STATUS_OK;
+}
+
+void
 AmclNode::initialPoseReceived(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
 {
   std::lock_guard<std::recursive_mutex> cfl(mutex_);
@@ -1418,6 +1428,10 @@ AmclNode::initServices()
   nomotion_update_srv_ = create_service<std_srvs::srv::Empty>(
     "request_nomotion_update",
     std::bind(&AmclNode::nomotionUpdateCallback, this, _1, _2, _3));
+
+  get_initial_pose_status_srv_ = this->create_service<cmr_msgs::srv::GetStatus>(
+    "get_initial_pose_status",
+    std::bind(&AmclNode::getInitialPoseStatusCallback, this, _1, _2));
 }
 
 void


### PR DESCRIPTION
## Purpose
It is a part of implementation of `Initial pose set up with fiducials` feature. We need a way to know if amcl has already received an initial pose.

## Approach
Current amcl implementation has already a variable `initial_pose_is_known_`. I added `GetStatus` service which returns status based on  `initial_pose_is_known_` variable.