### PR TITLE
AMCL evaluate accuracy (Nav-1379)

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -6,12 +6,12 @@ find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(message_filters REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -53,12 +53,12 @@ set(dependencies
   rclcpp
   rclcpp_lifecycle
   message_filters
+  diagnostic_updater
   tf2_geometry_msgs
   geometry_msgs
   nav_msgs
   sensor_msgs
   std_srvs
-  std_msgs
   tf2_ros
   tf2
   nav2_util

--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -57,6 +58,7 @@ set(dependencies
   nav_msgs
   sensor_msgs
   std_srvs
+  std_msgs
   tf2_ros
   tf2
   nav2_util

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -40,11 +40,11 @@
 #include "nav2_msgs/msg/particle_cloud.hpp"
 #include "nav_msgs/srv/set_map.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
-#include <std_msgs/msg/bool.hpp>
 #include "std_srvs/srv/empty.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include "cmr_msgs/srv/get_status.hpp"
 
 #pragma GCC diagnostic push
@@ -185,8 +185,6 @@ protected:
     pose_pub_;
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::ParticleCloud>::SharedPtr
     particle_cloud_pub_;
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
-    amcl_lost_flag_pub_;
   /*
    * @brief Handle with an initial pose estimate is received
    */
@@ -242,6 +240,13 @@ protected:
   geometry_msgs::msg::PoseWithCovarianceStamped last_published_pose_;
   double init_pose_[3];  // Initial robot pose
   double init_cov_[3];
+
+  // Diagnostic
+  /*
+   * @brief Initialize Diagnostic
+   */
+  void initDiagnostic();
+
   /*
    * @brief Get robot pose in odom frame using TF
    */
@@ -276,11 +281,15 @@ protected:
    */
   void initExternalPose();
   /*
-   * @brief Publish deviation diagnostic flag
+   * @brief Diagnostic checking robot's covariance
    * @ true if deviation gets large
    *
    */
-  void publishStandardDeviationFlag();
+  diagnostic_updater::Updater diagnostic_updater_;
+  void standardDeviationDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat);
+  double std_warn_level_x_;
+  double std_warn_level_y_;
+  double std_warn_level_yaw_;
 
   ExternalPoseBuffer ext_pose_buffer;
 
@@ -413,9 +422,6 @@ protected:
   double z_rand_;
   double k_l_;
   bool fuse_external_pose_;
-  double std_warn_level_x_;
-  double std_warn_level_y_;
-  double std_warn_level_yaw_;
   std::string scan_topic_{"scan"};
   std::string map_topic_{"map"};
 };

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -40,6 +40,7 @@
 #include "nav2_msgs/msg/particle_cloud.hpp"
 #include "nav_msgs/srv/set_map.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
+#include <std_msgs/msg/bool.hpp>
 #include "std_srvs/srv/empty.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
@@ -184,6 +185,8 @@ protected:
     pose_pub_;
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::ParticleCloud>::SharedPtr
     particle_cloud_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
+    amcl_lost_flag_pub_;
   /*
    * @brief Handle with an initial pose estimate is received
    */

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -275,7 +275,7 @@ protected:
   /*
    * @brief Deviation diagnostic flag
    */
-  void standardDeviationFlag();
+  void setStandardDeviationFlag();
 
   ExternalPoseBuffer ext_pose_buffer;
 

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -276,9 +276,11 @@ protected:
    */
   void initExternalPose();
   /*
-   * @brief Deviation diagnostic flag
+   * @brief Publish deviation diagnostic flag
+   * @ true if deviation gets large
+   *
    */
-  void setStandardDeviationFlag();
+  void publishStandardDeviationFlag();
 
   ExternalPoseBuffer ext_pose_buffer;
 

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -272,6 +272,10 @@ protected:
    * @brief Initialize external pose data source
    */
   void initExternalPose();
+  /*
+   * @brief Deviation diagnostic flag
+   */
+  void standardDeviationFlag();
 
   ExternalPoseBuffer ext_pose_buffer;
 
@@ -404,6 +408,9 @@ protected:
   double z_rand_;
   double k_l_;
   bool fuse_external_pose_;
+  double std_warn_level_x_;
+  double std_warn_level_y_;
+  double std_warn_level_yaw_;
   std::string scan_topic_{"scan"};
   std::string map_topic_{"map"};
 };

--- a/nav2_amcl/package.xml
+++ b/nav2_amcl/package.xml
@@ -23,13 +23,13 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
   <depend>rclcpp</depend>
+  <depend>diagnostic_updater</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>std_msgs</depend>
   <depend>cmr_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2</depend>

--- a/nav2_amcl/package.xml
+++ b/nav2_amcl/package.xml
@@ -29,6 +29,7 @@
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>std_msgs</depend>
   <depend>cmr_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2</depend>

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -842,7 +842,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     int max_weight_hyp = -1;
     if (getMaxWeightHyp(hyps, max_weight_hyps, max_weight_hyp)) {
       publishAmclPose(laser_scan, hyps, max_weight_hyp); // estimated_pose = pose(best_cluster.mean, filter.covariance)
-      setStandardDeviationFlag();
+      publishStandardDeviationFlag();
       calculateMaptoOdomTransform(laser_scan, hyps, max_weight_hyp);
 
       if (tf_broadcast_ == true) {
@@ -1536,8 +1536,11 @@ AmclNode::initExternalPose()
   ext_pose_active_ = false;
 }
 
+// Publish estimated standard deviation flag of the filter, coming from pose covariance
+// 'true' if exceeds any of threshold
+// Based on https://github.com/ros-planning/navigation/pull/807
 void
-AmclNode::setStandardDeviationFlag()
+AmclNode::publishStandardDeviationFlag()
 {
   double std_x = sqrt(last_published_pose_.pose.covariance[6*0+0]);
   double std_y = sqrt(last_published_pose_.pose.covariance[6*1+1]);
@@ -1552,7 +1555,6 @@ AmclNode::setStandardDeviationFlag()
   }
   else
   {
-    RCLCPP_INFO(get_logger(), "OK");
     msg.data = false;
     amcl_lost_flag_pub_->publish(msg);
   }

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -293,6 +293,7 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
   // Lifecycle publishers must be explicitly activated
   pose_pub_->on_activate();
   particle_cloud_pub_->on_activate();
+  amcl_lost_flag_pub_->on_activate();
 
   first_pose_sent_ = false;
 
@@ -331,6 +332,7 @@ AmclNode::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   // Lifecycle publishers must be explicitly deactivated
   pose_pub_->on_deactivate();
   particle_cloud_pub_->on_deactivate();
+  amcl_lost_flag_pub_->on_deactivate();
 
   // destroy bond connection
   destroyBond();
@@ -368,6 +370,7 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   // PubSub
   pose_pub_.reset();
   particle_cloud_pub_.reset();
+  amcl_lost_flag_pub_.reset();
 
   // Odometry
   motion_model_.reset();
@@ -838,7 +841,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     std::vector<amcl_hyp_t> hyps;
     int max_weight_hyp = -1;
     if (getMaxWeightHyp(hyps, max_weight_hyps, max_weight_hyp)) {
-      publishAmclPose(laser_scan, hyps, max_weight_hyp);
+      publishAmclPose(laser_scan, hyps, max_weight_hyp); // estimated_pose = pose(best_cluster.mean, filter.covariance)
       setStandardDeviationFlag();
       calculateMaptoOdomTransform(laser_scan, hyps, max_weight_hyp);
 
@@ -1426,6 +1429,10 @@ AmclNode::initPubSub()
     "amcl_pose",
     rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
 
+  amcl_lost_flag_pub_ = create_publisher<std_msgs::msg::Bool>(
+    "amcl_lost_flag",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+
   initial_pose_sub_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "initialpose", rclcpp::SystemDefaultsQoS(),
     std::bind(&AmclNode::initialPoseReceived, this, std::placeholders::_1));
@@ -1536,13 +1543,18 @@ AmclNode::setStandardDeviationFlag()
   double std_y = sqrt(last_published_pose_.pose.covariance[6*1+1]);
   double std_yaw = sqrt(last_published_pose_.pose.covariance[6*5+5]);
 
+  std_msgs::msg::Bool msg;
   if (std_x > std_warn_level_x_ || std_y > std_warn_level_y_ || std_yaw > std_warn_level_yaw_)
   {
     RCLCPP_WARN(get_logger(), "Deviation too large");
+    msg.data = true;
+    amcl_lost_flag_pub_->publish(msg);
   }
   else
   {
     RCLCPP_INFO(get_logger(), "OK");
+    msg.data = false;
+    amcl_lost_flag_pub_->publish(msg);
   }
 }
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -227,6 +227,18 @@ AmclNode::AmclNode()
   add_parameter(
     "k_l", rclcpp::ParameterValue(200.0f),
     "Constant to balance the importance of the external pose data");
+
+    add_parameter(
+      "std_warn_level_x", rclcpp::ParameterValue(0.2),
+      "Limit threshold of x value. Monitors the estimated standard deviation of the filter.");
+
+    add_parameter(
+      "std_warn_level_y", rclcpp::ParameterValue(0.2),
+      "Limit threshold of y value. Monitors the estimated standard deviation of the filter.");
+
+    add_parameter(
+      "std_warn_level_yaw", rclcpp::ParameterValue(0.1),
+      "Limit threshold of yaw value. Monitors the estimated standard deviation of the filter.");
 }
 
 AmclNode::~AmclNode()
@@ -827,6 +839,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     int max_weight_hyp = -1;
     if (getMaxWeightHyp(hyps, max_weight_hyps, max_weight_hyp)) {
       publishAmclPose(laser_scan, hyps, max_weight_hyp);
+      standardDeviationFlag();
       calculateMaptoOdomTransform(laser_scan, hyps, max_weight_hyp);
 
       if (tf_broadcast_ == true) {
@@ -1078,7 +1091,7 @@ AmclNode::publishAmclPose(
   temp += p->pose.pose.position.x + p->pose.pose.position.y;
   if (!std::isnan(temp)) {
     RCLCPP_DEBUG(get_logger(), "Publishing pose");
-    last_published_pose_ = *p;
+    last_published_pose_ = *p; // Update last_published_pose_
     first_pose_sent_ = true;
     pose_pub_->publish(std::move(p));
   } else {
@@ -1212,6 +1225,9 @@ AmclNode::initParameters()
   get_parameter("scan_topic", scan_topic_);
   get_parameter("map_topic", map_topic_);
   get_parameter("k_l", k_l_);
+  get_parameter("std_warn_level_x", std_warn_level_x_);
+  get_parameter("std_warn_level_y", std_warn_level_y_);
+  get_parameter("std_warn_level_yaw", std_warn_level_yaw_);
   save_pose_period_ = tf2::durationFromSec(1.0 / save_pose_rate);
   transform_tolerance_ = tf2::durationFromSec(tmp_tol);
 
@@ -1504,6 +1520,23 @@ AmclNode::initExternalPose()
   last_laser_received_ts_ = rclcpp::Time(0);
   ext_pose_check_interval_ = std::chrono::seconds{1};
   ext_pose_active_ = false;
+}
+
+void
+AmclNode::standardDeviationFlag()
+{
+  double std_x = sqrt(last_published_pose_.pose.covariance[6*0+0]);
+  double std_y = sqrt(last_published_pose_.pose.covariance[6*1+1]);
+  double std_yaw = sqrt(last_published_pose_.pose.covariance[6*5+5]);
+
+  if (std_x > std_warn_level_x_ || std_y > std_warn_level_y_ || std_yaw > std_warn_level_yaw_)
+  {
+    RCLCPP_WARN(get_logger(), "Deviation too large");
+  }
+  else
+  {
+    RCLCPP_INFO(get_logger(), "OK");
+  }
 }
 
 }  // namespace nav2_amcl

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -839,7 +839,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     int max_weight_hyp = -1;
     if (getMaxWeightHyp(hyps, max_weight_hyps, max_weight_hyp)) {
       publishAmclPose(laser_scan, hyps, max_weight_hyp);
-      standardDeviationFlag();
+      setStandardDeviationFlag();
       calculateMaptoOdomTransform(laser_scan, hyps, max_weight_hyp);
 
       if (tf_broadcast_ == true) {
@@ -1029,8 +1029,15 @@ AmclNode::getMaxWeightHyp(
     hyps[hyp_count].weight = weight;
     hyps[hyp_count].pf_pose_mean = pose_mean;
     hyps[hyp_count].pf_pose_cov = pose_cov;
+    RCLCPP_DEBUG(
+      get_logger(), "Hypotheses No %i:\t weight: %.3f",
+      hyp_count+1, hyps[hyp_count].weight);
 
     if (hyps[hyp_count].weight > max_weight) {
+      RCLCPP_DEBUG(get_logger(), "Max weight:\t %f", max_weight);
+      RCLCPP_DEBUG(get_logger(), "Hyp weight:\t %f", hyps[hyp_count].weight);
+      RCLCPP_DEBUG(get_logger(), "CHANGED MAX WEIGHT OR NO HAVING WEIGHT YET");
+
       max_weight = hyps[hyp_count].weight;
       max_weight_hyp = hyp_count;
     }
@@ -1523,7 +1530,7 @@ AmclNode::initExternalPose()
 }
 
 void
-AmclNode::standardDeviationFlag()
+AmclNode::setStandardDeviationFlag()
 {
   double std_x = sqrt(last_published_pose_.pose.covariance[6*0+0]);
   double std_y = sqrt(last_published_pose_.pose.covariance[6*1+1]);

--- a/nav2_amcl/src/pf/pf.c
+++ b/nav2_amcl/src/pf/pf.c
@@ -713,7 +713,8 @@ void pf_cluster_stats(pf_t * pf, pf_sample_set_t * set)
     cluster->cov.m[2][2] = -2 * log(
       sqrt(
         cluster->m[2] * cluster->m[2] +
-        cluster->m[3] * cluster->m[3]));
+        // AMCL miscalculates orientation covariance for clusters https://github.com/ros-planning/navigation/issues/1160
+        cluster->m[3] * cluster->m[3]) / cluster->weight);
 
     // printf("cluster %d %d %f (%f %f %f)\n", i, cluster->count, cluster->weight,
     // cluster->mean.v[0], cluster->mean.v[1], cluster->mean.v[2]);


### PR DESCRIPTION
## Purpose
The following PR Proposes AMCL evaluation technique, which monitors the estimated standard deviation of the filter, using covariance from the robot's pose and publishes a bool-type flag:
* `False` if pose is not yet known;
* `False` if covariance of pose chosen by AMCL is acceptable and not exceeds **any** of thresholds set;
* `True` if values higher than `std_warn_level_x`, `std_warn_level_y,` `std_warn_level_yaw`

Values can be adjusted in parameter server.  Tested in a simulation with manually changing robot's pose in Rviz, values seem to be well-chosen.

* Fix: AMCL miscalculates orientation covariance for clusters
* Add extra DEBUG logging

[EDIT]: Flag can be moved to Diagnostics monitoring