### PR TITLE
Add transfrom lookup param

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -414,6 +414,7 @@ protected:
   double sigma_hit_;
   bool tf_broadcast_;
   tf2::Duration transform_tolerance_;
+  tf2::Duration transform_lookup_timeout_;
   double a_thresh_;
   double d_thresh_;
   double z_hit_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -690,7 +690,7 @@ AmclNode::handleInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped & msg)
     // Check if the transform is available
     tx_odom = tf_buffer_->lookupTransform(
       base_frame_id_, tf2_ros::fromMsg(msg.header.stamp),
-      base_frame_id_, tf2_time, odom_frame_id_, extrapolation_into_past_tolerance_);
+      base_frame_id_, tf2_time, odom_frame_id_, transform_lookup_timeout_);
   } catch (tf2::TransformException & e) {
     // If we've never sent a transform, then this is normal, because the
     // global_frame_id_ frame doesn't exist.  We only care about in-time

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -199,6 +199,10 @@ AmclNode::AmclNode()
     "is valid into the future");
 
   add_parameter(
+    "transform_lookup_timeout", rclcpp::ParameterValue(0.1f),
+    "Timeout value for transform lookup");
+
+  add_parameter(
     "update_min_a", rclcpp::ParameterValue(0.2),
     "Rotational movement required before performing a filter update");
 
@@ -686,7 +690,7 @@ AmclNode::handleInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped & msg)
     // Check if the transform is available
     tx_odom = tf_buffer_->lookupTransform(
       base_frame_id_, tf2_ros::fromMsg(msg.header.stamp),
-      base_frame_id_, tf2_time, odom_frame_id_);
+      base_frame_id_, tf2_time, odom_frame_id_, extrapolation_into_past_tolerance_);
   } catch (tf2::TransformException & e) {
     // If we've never sent a transform, then this is normal, because the
     // global_frame_id_ frame doesn't exist.  We only care about in-time
@@ -1199,6 +1203,7 @@ AmclNode::initParameters()
 {
   double save_pose_rate;
   double tmp_tol;
+  double lookup_timeout;
 
   get_parameter("alpha1", alpha1_);
   get_parameter("alpha2", alpha2_);
@@ -1235,6 +1240,7 @@ AmclNode::initParameters()
   get_parameter("sigma_hit", sigma_hit_);
   get_parameter("tf_broadcast", tf_broadcast_);
   get_parameter("transform_tolerance", tmp_tol);
+  get_parameter("transform_lookup_timeout", lookup_timeout);
   get_parameter("update_min_a", a_thresh_);
   get_parameter("update_min_d", d_thresh_);
   get_parameter("z_hit", z_hit_);
@@ -1254,6 +1260,7 @@ AmclNode::initParameters()
   
   save_pose_period_ = tf2::durationFromSec(1.0 / save_pose_rate);
   transform_tolerance_ = tf2::durationFromSec(tmp_tol);
+  transform_lookup_timeout_ = tf2::durationFromSec(lookup_timeout);
 
   odom_frame_id_ = nav2_util::strip_leading_slash(odom_frame_id_);
   base_frame_id_ = nav2_util::strip_leading_slash(base_frame_id_);


### PR DESCRIPTION
## Purpose
When setting up initial pose, AMCL look for transformation from initial pose time (in `base_footprint`) to now (in `base_footprint`) (relative to `odom` frame) to account for movement that happened in that period. Sometimes lookupTransform throws `Extrapolation into the past` error, because `now` is later than latest `base_footprint->odom` transform.

## Approach
`lookupTransform` timeout parameter, which make it wait for `timeout` seconds before throwing an error.
