### PR TITLE
Dynamic parameters tuning

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1526,10 +1526,6 @@ AmclNode::dynamicParametersCallback(
     lasers_.clear();
     lasers_update_.clear();
     frame_to_laser_.clear();
-    laser_scan_connection_.disconnect();
-    laser_scan_sub_.reset();
-
-    initMessageFilters();
   }
 
   // Re-initialize the map

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1401,9 +1401,7 @@ AmclNode::dynamicParametersCallback(
         sigma_hit_ = parameter.as_double();
         reinit_laser = true;
       } else if (param_name == "transform_tolerance") {
-        tmp_tol = parameter.as_double();
-        transform_tolerance_ = tf2::durationFromSec(tmp_tol);
-        reinit_laser = true;
+        RCLCPP_WARN(get_logger(), "Cannot change param [%s] due to issue with reinitialization of message filters (#28)", param_name.c_str());
       } else if (param_name == "update_min_a") {
         a_thresh_ = parameter.as_double();
       } else if (param_name == "update_min_d") {
@@ -1448,11 +1446,9 @@ AmclNode::dynamicParametersCallback(
         sensor_model_type_ = parameter.as_string();
         reinit_laser = true;
       } else if (param_name == "odom_frame_id") {
-        odom_frame_id_ = parameter.as_string();
-        reinit_laser = true;
+        RCLCPP_WARN(get_logger(), "Cannot change param [%s] due to issue with reinitialization of message filters (#28)", param_name.c_str());
       } else if (param_name == "scan_topic") {
-        scan_topic_ = parameter.as_string();
-        reinit_laser = true;
+        RCLCPP_WARN(get_logger(), "Cannot change param [%s] due to issue with reinitialization of message filters (#28)", param_name.c_str());
       } else if (param_name == "robot_model_type") {
         robot_model_type_ = parameter.as_string();
         reinit_odom = true;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1431,7 +1431,7 @@ AmclNode::dynamicParametersCallback(
         reinit_laser = true;
       } else if (param_name == "max_particle_gen_prob_ext_pose") {
         max_particle_gen_prob_ext_pose_ = parameter.as_double();
-        reinit_pf = true;
+        pf_->max_particle_gen_prob_ext_pose = max_particle_gen_prob_ext_pose_;
       } else if (param_name == "ext_pose_search_tolerance_sec") {
         ext_pose_search_tolerance_sec_ = parameter.as_double();
         reinit_ext_pose = true;


### PR DESCRIPTION
## Purpose
1. When changing particle filter parameters, the filter is initialized again which stops the calculation of the robot pose. So I changed the way `max_particle_gen_prob_ext_pose` is changed, I just assign it directly to the particle filter structure member now.
2. Changing laser model parameters start reinitialization of message filters also, which for unknown reason makes amcl crash (#28 I'll provide more info on the issue later). Removing the reinitialization of the message filter stops crashes

## Disclaimers
The way we change particle filter parameters during dynamic reconfiguring should change for all parameters, not only for `max_particle_gen_prob_ext_pose`, I know, but I'm leaving it for later - #30.