### PR TITLE
AMCL pose calculation by averaging clusters

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -355,6 +355,11 @@ protected:
    */
   void publishParticleCloud(const pf_sample_set_t * set);
   /*
+  * @brief Get the current state estimate hypothesis from the particle cloud
+  * by calculating mean weighted centroid among cluster centroids
+  */
+  bool getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid_hyp);
+  /*
    * @brief Get the current state estimat hypothesis from the particle cloud
    */
   bool getMaxWeightHyp(

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -358,7 +358,7 @@ protected:
   * @brief Get the current state estimate hypothesis from the particle cloud
   * by calculating mean weighted centroid among cluster centroids
   */
-  bool getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid_hyp);
+  bool getMeanWeightedClustersCentroid(amcl_hyp_t & mean_centroid_hyp);
   /*
    * @brief Get the current state estimat hypothesis from the particle cloud
    */

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -362,22 +362,17 @@ protected:
   /*
    * @brief Get the current state estimat hypothesis from the particle cloud
    */
-  bool getMaxWeightHyp(
-    std::vector<amcl_hyp_t> & hyps, amcl_hyp_t & max_weight_hyps,
-    int & max_weight_hyp);
+  bool getMaxWeightHyp(amcl_hyp_t & max_weight_hyp);
   /*
    * @brief Publish robot pose in map frame from AMCL
    */
-  void publishAmclPose(
-    const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
-    const std::vector<amcl_hyp_t> & hyps, const int & max_weight_hyp);
+  void publishAmclPose(const amcl_hyp_t & best_hyp,
+    const builtin_interfaces::msg::Time & timestamp_msg);
   /*
    * @brief Determine TF transformation from map to odom
    */
-  void calculateMaptoOdomTransform(
-    const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
-    const std::vector<amcl_hyp_t> & hyps,
-    const int & max_weight_hyp);
+  void calculateMaptoOdomTransform(const amcl_hyp_t & best_hyp,
+    const builtin_interfaces::msg::Time & timestamp_msg);
   /*
    * @brief Publish TF transformation from map to odom
    */
@@ -441,6 +436,7 @@ protected:
   double ext_pose_search_tolerance_sec_;
   std::string scan_topic_{"scan"};
   std::string map_topic_{"map"};
+  bool use_cluster_averaging_;
 };
 
 }  // namespace nav2_amcl

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -253,6 +253,11 @@ AmclNode::AmclNode()
   add_parameter(
     "ext_pose_search_tolerance_sec", rclcpp::ParameterValue(0.1f),
     "Time tolerance for corresponding external pose measurement search");
+
+  add_parameter(
+    "use_cluster_averaging", rclcpp::ParameterValue(false),
+    "Average (with weights) cluster centroid positions when calculating curren pose"
+  );
 }
 
 AmclNode::~AmclNode()
@@ -863,12 +868,18 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     }
   }
   if (resampled || force_publication || !first_pose_sent_) {
-    amcl_hyp_t max_weight_hyps;
-    std::vector<amcl_hyp_t> hyps;
-    int max_weight_hyp = -1;
-    if (getMaxWeightHyp(hyps, max_weight_hyps, max_weight_hyp)) {
-      publishAmclPose(laser_scan, hyps, max_weight_hyp); // estimated_pose = pose(best_cluster.mean, filter.covariance)
-      calculateMaptoOdomTransform(laser_scan, hyps, max_weight_hyp);
+    amcl_hyp_t best_hyp;
+    bool ret = false;
+
+    if(use_cluster_averaging_){
+      ret = getWeightedMeanClustersCenroid(best_hyp);
+    } else {
+      ret = getMaxWeightHyp(best_hyp);
+    }
+
+    if (ret) {
+      publishAmclPose(best_hyp, laser_scan->header.stamp); // estimated_pose = pose(best_cluster.mean, filter.covariance)
+      calculateMaptoOdomTransform(best_hyp, laser_scan->header.stamp);
 
       if (tf_broadcast_ == true) {
         // We want to send a transform that is good up until a
@@ -1075,10 +1086,11 @@ AmclNode::getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid){
     return true;
 }
 
+bool
+AmclNode::getMaxWeightHyp(amcl_hyp_t & max_weight_hyp)
 {
   // Read out the current hypotheses
   double max_weight = 0.0;
-  hyps.resize(pf_->sets[pf_->current_set].cluster_count);
   for (int hyp_count = 0;
     hyp_count < pf_->sets[pf_->current_set].cluster_count; hyp_count++)
   {
@@ -1090,31 +1102,34 @@ AmclNode::getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid){
       return false;
     }
 
-    hyps[hyp_count].weight = weight;
-    hyps[hyp_count].pf_pose_mean = pose_mean;
-    hyps[hyp_count].pf_pose_cov = pose_cov;
     RCLCPP_DEBUG(
       get_logger(), "Hypotheses No %i:\t weight: %.3f",
-      hyp_count+1, hyps[hyp_count].weight);
+      hyp_count+1, weight);
+      RCLCPP_DEBUG(
+      get_logger(), "Pose: %.3f %.3f %.3f",
+      pose_mean.v[0],
+      pose_mean.v[1],
+      pose_mean.v[2]);
 
-    if (hyps[hyp_count].weight > max_weight) {
+    if (weight > max_weight) {
       RCLCPP_DEBUG(get_logger(), "Max weight:\t %f", max_weight);
-      RCLCPP_DEBUG(get_logger(), "Hyp weight:\t %f", hyps[hyp_count].weight);
+      RCLCPP_DEBUG(get_logger(), "Hyp weight:\t %f", weight);
       RCLCPP_DEBUG(get_logger(), "CHANGED MAX WEIGHT OR NO HAVING WEIGHT YET");
 
-      max_weight = hyps[hyp_count].weight;
-      max_weight_hyp = hyp_count;
+      max_weight = weight;
+
+      max_weight_hyp.weight = weight;
+      max_weight_hyp.pf_pose_mean = pose_mean;
+      max_weight_hyp.pf_pose_cov = pose_cov;
     }
   }
 
   if (max_weight > 0.0) {
     RCLCPP_DEBUG(
       get_logger(), "Max weight pose: %.3f %.3f %.3f",
-      hyps[max_weight_hyp].pf_pose_mean.v[0],
-      hyps[max_weight_hyp].pf_pose_mean.v[1],
-      hyps[max_weight_hyp].pf_pose_mean.v[2]);
-
-    max_weight_hyps = hyps[max_weight_hyp];
+      max_weight_hyp.pf_pose_mean.v[0],
+      max_weight_hyp.pf_pose_mean.v[1],
+      max_weight_hyp.pf_pose_mean.v[2]);
     return true;
   }
   return false;
@@ -1122,8 +1137,8 @@ AmclNode::getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid){
 
 void
 AmclNode::publishAmclPose(
-  const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
-  const std::vector<amcl_hyp_t> & hyps, const int & max_weight_hyp)
+  const amcl_hyp_t & best_hyp,
+  const builtin_interfaces::msg::Time & timestamp_msg)
 {
   // If initial pose is not known, AMCL does not know the current pose
   if (!initial_pose_is_known_) {
@@ -1139,18 +1154,18 @@ AmclNode::publishAmclPose(
   auto p = std::make_unique<geometry_msgs::msg::PoseWithCovarianceStamped>();
   // Fill in the header
   p->header.frame_id = global_frame_id_;
-  p->header.stamp = laser_scan->header.stamp;
+  p->header.stamp = timestamp_msg;
   // Copy in the pose
-  p->pose.pose.position.x = hyps[max_weight_hyp].pf_pose_mean.v[0];
-  p->pose.pose.position.y = hyps[max_weight_hyp].pf_pose_mean.v[1];
-  p->pose.pose.orientation = orientationAroundZAxis(hyps[max_weight_hyp].pf_pose_mean.v[2]);
+  p->pose.pose.position.x = best_hyp.pf_pose_mean.v[0];
+  p->pose.pose.position.y = best_hyp.pf_pose_mean.v[1];
+  p->pose.pose.orientation = orientationAroundZAxis(best_hyp.pf_pose_mean.v[2]);
   // Copy in the covariance, converting from 3-D to 6-D
   pf_sample_set_t * set = pf_->sets + pf_->current_set;
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
       // Report the overall filter covariance, rather than the
       // covariance for the highest-weight cluster
-      // p->covariance[6*i+j] = hyps[max_weight_hyp].pf_pose_cov.m[i][j];
+      // p->covariance[6*i+j] = best_hyp.pf_pose_cov.m[i][j];
       p->pose.covariance[6 * i + j] = set->cov.m[i][j];
     }
   }
@@ -1173,29 +1188,29 @@ AmclNode::publishAmclPose(
 
   RCLCPP_DEBUG(
     get_logger(), "New pose: %6.3f %6.3f %6.3f",
-    hyps[max_weight_hyp].pf_pose_mean.v[0],
-    hyps[max_weight_hyp].pf_pose_mean.v[1],
-    hyps[max_weight_hyp].pf_pose_mean.v[2]);
+    best_hyp.pf_pose_mean.v[0],
+    best_hyp.pf_pose_mean.v[1],
+    best_hyp.pf_pose_mean.v[2]);
 }
 
 void
 AmclNode::calculateMaptoOdomTransform(
-  const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
-  const std::vector<amcl_hyp_t> & hyps, const int & max_weight_hyp)
+  const amcl_hyp_t & best_hyp,
+  const builtin_interfaces::msg::Time & timestamp_msg)
 {
   // subtracting base to odom from map to base and send map to odom instead
   geometry_msgs::msg::PoseStamped odom_to_map;
   try {
     tf2::Quaternion q;
-    q.setRPY(0, 0, hyps[max_weight_hyp].pf_pose_mean.v[2]);
+    q.setRPY(0, 0, best_hyp.pf_pose_mean.v[2]);
     tf2::Transform tmp_tf(q, tf2::Vector3(
-        hyps[max_weight_hyp].pf_pose_mean.v[0],
-        hyps[max_weight_hyp].pf_pose_mean.v[1],
+        best_hyp.pf_pose_mean.v[0],
+        best_hyp.pf_pose_mean.v[1],
         0.0));
 
     geometry_msgs::msg::PoseStamped tmp_tf_stamped;
     tmp_tf_stamped.header.frame_id = base_frame_id_;
-    tmp_tf_stamped.header.stamp = laser_scan->header.stamp;
+    tmp_tf_stamped.header.stamp = timestamp_msg;
     tf2::toMsg(tmp_tf.inverse(), tmp_tf_stamped.pose);
 
     tf_buffer_->transform(tmp_tf_stamped, odom_to_map, odom_frame_id_);
@@ -1303,6 +1318,7 @@ AmclNode::initParameters()
   get_parameter("std_warn_level_yaw", std_warn_level_yaw_);
   get_parameter("max_particle_gen_prob_ext_pose", max_particle_gen_prob_ext_pose_);
   get_parameter("ext_pose_search_tolerance_sec", ext_pose_search_tolerance_sec_);
+  get_parameter("use_cluster_averaging", use_cluster_averaging_);
   
   save_pose_period_ = tf2::durationFromSec(1.0 / save_pose_rate);
   transform_tolerance_ = tf2::durationFromSec(tmp_tol);

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1052,6 +1052,7 @@ AmclNode::getMeanWeightedClustersCentroid(amcl_hyp_t & mean_centroid){
     double weighted_x = 0.0;    
     double weighted_y = 0.0;
     double weighted_yaw = 0.0;
+    double weighted_w = 0.0;
     for (int cluster_idx = 0;
       cluster_idx < pf_->sets[pf_->current_set].cluster_count; cluster_idx++)
     {
@@ -1067,17 +1068,18 @@ AmclNode::getMeanWeightedClustersCentroid(amcl_hyp_t & mean_centroid){
       weighted_y += pose_mean.v[1] * weight;
       weighted_yaw += pose_mean.v[2] * weight;
 
+      weighted_w += weight * weight;
     }
 
     mean_centroid.pf_pose_mean.v[0] = weighted_x;
     mean_centroid.pf_pose_mean.v[1] = weighted_y;
     mean_centroid.pf_pose_mean.v[2] = weighted_yaw;
 
-    // As we take information from all clusters (whose total weight is 1)
-    // we assign weight of that cluster also to 1
-    mean_centroid.weight = 1.0;
+    mean_centroid.weight = weighted_w;
+;
 
     RCLCPP_DEBUG(get_logger(), "Mean centroid pose: [%f, %f, %f]", weighted_x, weighted_y, weighted_yaw);
+    RCLCPP_DEBUG(get_logger(), "Mean centroid weight: [%f]", weighted_w);
 
     return true;
 }

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1052,7 +1052,6 @@ AmclNode::getMeanWeightedClustersCentroid(amcl_hyp_t & mean_centroid){
     double weighted_x = 0.0;    
     double weighted_y = 0.0;
     double weighted_yaw = 0.0;
-    double mean_weight = 0.0;
     for (int cluster_idx = 0;
       cluster_idx < pf_->sets[pf_->current_set].cluster_count; cluster_idx++)
     {
@@ -1068,20 +1067,17 @@ AmclNode::getMeanWeightedClustersCentroid(amcl_hyp_t & mean_centroid){
       weighted_y += pose_mean.v[1] * weight;
       weighted_yaw += pose_mean.v[2] * weight;
 
-      mean_weight += weight;
     }
-
-    if(mean_weight == 0.0) return false;
-
-    mean_weight /= pf_->sets[pf_->current_set].cluster_count;
 
     mean_centroid.pf_pose_mean.v[0] = weighted_x;
     mean_centroid.pf_pose_mean.v[1] = weighted_y;
     mean_centroid.pf_pose_mean.v[2] = weighted_yaw;
-    mean_centroid.weight = mean_weight;
+
+    // As we take information from all clusters (whose total weight is 1)
+    // we assign weight of that cluster also to 1
+    mean_centroid.weight = 1.0;
 
     RCLCPP_DEBUG(get_logger(), "Mean centroid pose: [%f, %f, %f]", weighted_x, weighted_y, weighted_yaw);
-    RCLCPP_DEBUG(get_logger(), "Mean centroid weight: [%f]", mean_weight);
 
     return true;
 }

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1037,9 +1037,44 @@ AmclNode::publishParticleCloud(const pf_sample_set_t * set)
 }
 
 bool
-AmclNode::getMaxWeightHyp(
-  std::vector<amcl_hyp_t> & hyps, amcl_hyp_t & max_weight_hyps,
-  int & max_weight_hyp)
+AmclNode::getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid){
+    double weighted_x = 0.0;    
+    double weighted_y = 0.0;
+    double weighted_yaw = 0.0;
+    double mean_weight = 0.0;
+    for (int cluster_idx = 0; 
+      cluster_idx < pf_->sets[pf_->current_set].cluster_count; cluster_idx++)
+    {
+      double weight;
+      pf_vector_t pose_mean;
+      pf_matrix_t pose_cov;
+      if (!pf_get_cluster_stats(pf_, cluster_idx, &weight, &pose_mean, &pose_cov)) {
+        RCLCPP_ERROR(get_logger(), "Couldn't get stats on cluster %d", cluster_idx);
+        return false;
+      }
+
+      weighted_x += pose_mean.v[0] * weight;
+      weighted_y += pose_mean.v[1] * weight;
+      weighted_yaw += pose_mean.v[2] * weight;
+
+      mean_weight += weight;
+    }
+
+    if(mean_weight == 0.0) return false;
+
+    mean_weight /= pf_->sets[pf_->current_set].cluster_count;
+
+    mean_centroid.pf_pose_mean.v[0] = weighted_x;
+    mean_centroid.pf_pose_mean.v[1] = weighted_y;
+    mean_centroid.pf_pose_mean.v[2] = weighted_yaw;
+    mean_centroid.weight = mean_weight;
+
+    RCLCPP_DEBUG(get_logger(), "Mean centroid pose: [%f, %f, %f]", weighted_x, weighted_y, weighted_yaw);
+    RCLCPP_DEBUG(get_logger(), "Mean centroid weight: [%f]", mean_weight);
+
+    return true;
+}
+
 {
   // Read out the current hypotheses
   double max_weight = 0.0;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -872,7 +872,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     bool ret = false;
 
     if(use_cluster_averaging_){
-      ret = getWeightedMeanClustersCenroid(best_hyp);
+      ret = getMeanWeightedClustersCentroid(best_hyp);
     } else {
       ret = getMaxWeightHyp(best_hyp);
     }
@@ -1048,12 +1048,12 @@ AmclNode::publishParticleCloud(const pf_sample_set_t * set)
 }
 
 bool
-AmclNode::getWeightedMeanClustersCenroid(amcl_hyp_t & mean_centroid){
+AmclNode::getMeanWeightedClustersCentroid(amcl_hyp_t & mean_centroid){
     double weighted_x = 0.0;    
     double weighted_y = 0.0;
     double weighted_yaw = 0.0;
     double mean_weight = 0.0;
-    for (int cluster_idx = 0; 
+    for (int cluster_idx = 0;
       cluster_idx < pf_->sets[pf_->current_set].cluster_count; cluster_idx++)
     {
       double weight;


### PR DESCRIPTION
## Purpose
Robot can jump by a considerable distance currently as AMCL assign the robot pose to a centroid of the largest cluster, so when the current cluster is not the largest anymore, the pose jumps for the most significant cluster right now. 
My idea: let's assign robot pose to the weighted (based on cluster weights) average of cluster centroids, that _in theory_ will give us a smooth transition when the largest cluster changes. 

## Approach
- Add function for calculation of the weighted average of the cluster centroids
- Add parameter for switching between old and new pose calculation regime.
- Refactor `publishAmclPose`, `calculateMaptoOdomTransform` functions as they were receiving the list of all clusters and the index of the max weight cluster to get the best hypothesis in the list, which is redundant in my opinion, so now they take the best hypothesis right away.