### PR TITLE
Update yaml_filename param SS-209

### DIFF
--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -199,6 +199,9 @@ void MapServer::loadMapCallback(
   if (loadMapResponseFromYaml(request->map_url, response)) {
     auto occ_grid = std::make_unique<nav_msgs::msg::OccupancyGrid>(msg_);
     occ_pub_->publish(std::move(occ_grid));  // publish new map
+
+    // update yaml_filename parameter
+    set_parameter(rclcpp::Parameter("yaml_filename", request->map_url));
   }
 }
 


### PR DESCRIPTION
## Purpose
We use service `/map_server/load_map` for elevator stuff. But that service doesn't update `yaml_filename` map_server parameter. 
I want `yaml_filename` to be up-to-date, as we will fetch that param to figure out what the current floor is (as we have a floor number in the file name, [link](https://github.com/cmrobotics/map_files/tree/PER-82-maps_for_switching_test)).