### PR TITLE
SS-232 Extended point cost collision check along global plan

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -189,6 +189,13 @@ protected:
     const double &, const double &,
     const double &);
 
+
+  /**
+   * @brief Checks point cost along the global plan upto a max_extended_collision_check_dist_
+   * @return Whether collision is imminent
+   */
+  bool isCollisionImminentExtendedSearch();
+
   /**
    * @brief checks for collision at projected pose
    * @param x Pose of pose x
@@ -306,10 +313,12 @@ protected:
   double goal_dist_tol_;
   bool allow_reversing_;
   double max_robot_pose_search_dist_;
+  double max_extended_collision_check_dist_;
   bool use_interpolation_;
 
   nav_msgs::msg::Path global_plan_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> extended_collision_check_path_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>>
   carrot_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> carrot_arc_pub_;


### PR DESCRIPTION
## Purpose
Reduce lookahead distance so that the robot follows the global plan more closely and prevents it from cutting corners (which leads to the robot getting stuck in tight spaces), **without** affecting how close the robot can get to obstacles.

With `use_velocity_scaled_lookahead_dist` enabled, lookahead distance is automatically lowered when approaching or navigating very close to obstacles, which helps it navigate around those obstacles without getting stuck, but it also means that it will get just as close to other obstacles in its path.

This is especially important when we exclude dynamic obstacles from global planning, as the robot will get as close as `min_lookahead_dist` to a moving obstacle in its path. Example: A person walking in front of the robot in the same direction.

## Approach
- In addition to the existing full SE2 collision check along the arc up to the carrot point, check for point cost collision along the global plan up to a fixed cumulative distance `max_extended_collision_check_dist`.
- This will give an approximate collision check beyond the lookahead arc without needing complex MPC-type computations.
-  Set `max_extended_collision_check_dist` param according to the footprint, and minimum safe distance requirements.

## Disclaimer
- For a more efficient extended collision check, it should be checking point cost starting **after** the carrot point on the global_plan_ but it is unclear if it is worth the additional computation of finding the carrot pose in the global frame and pruning out global_plan_ up to it in each iteration.
