### PR TITLE
Change laser importance based on Augmented MCL score SS-251

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,46 +1,30 @@
-<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
+## Purpose
+_Describe the problem or feature in addition to a link to the issues._
 
----
+## Approach
+_How does this change address the problem?_
 
-## Basic Info
+### Open Questions and Pre-Merge TODOs
+- [ ] Use github checklists. When solved, check the box and explain the answer.
 
-| Info | Please fill out this column |
-| ------ | ----------- |
-| Ticket(s) this addresses   | (add tickets here #1) |
-| Primary OS tested on | (Ubuntu, MacOS, Windows) |
-| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
+## Dependencies
+If this PR depends on changes introduced by other PRs, please list all the dependencies.
 
----
+ - `#xy` (use this syntax if the PR belongs to the same repo).
+ - `#package/xy` (use this syntax if the PR belongs to another repo).
 
-## Description of contribution in a few bullet points
+## Disclaimers
+Include here disclaimers that should be taken into consideration when considering your PR. Disclaimers
+could be, but are not limited to,
 
-<!--
-* I added this neat new feature
-* Also fixed a typo in a parameter name in nav2_costmap_2d
--->
+ - incorrect behaviors that are known and not addressed by this PR,
+ - limitations of the feature introduced by this PR, or
+ - assumptions made when solving an issue or developing a feature.
+ 
+## Learning
+_Describe the research stage_
 
-## Description of documentation updates required from your changes
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
 
-<!--
-* Added new parameter, so need to add that to default configs and documentation page
-* I added some capabilities, need to document them
--->
-
----
-
-## Future work that may be required in bullet points
-
-<!--
-* I think there might be some optimizations to be made from STL vector
-* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
-* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
--->
-
-#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
-- [ ] Check that any new parameters added are updated in navigation.ros.org
-- [ ] Check that any significant change is added to the migration guide
-- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-- [ ] Check that any new functions have Doxygen added
-- [ ] Check that any new features have test coverage
-- [ ] Check that any new plugins is added to the plugins page
-- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
+### Blog Posts
+- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_map>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
@@ -306,6 +307,20 @@ protected:
   double std_warn_level_x_;
   double std_warn_level_y_;
   double std_warn_level_yaw_;
+  double aug_mcl_score_threshold_;
+
+  std::string localization_mode_ = "";
+  rclcpp::Time last_mode_switch_ts_;
+
+  /*
+    * @brief Check localization health
+  */
+  void healthCheck();
+
+  void updateMetrics();
+  bool switchLocalizationMode(std::string mode);
+
+  std::unordered_map<std::string, double> metrics_;
 
   std::unique_ptr<ExternalPoseBuffer> ext_pose_buffer_;
 

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -318,7 +318,7 @@ protected:
   void healthCheck();
 
   void updateMetrics();
-  bool switchLocalizationMode(std::string mode);
+  void updateLaserImportance(double correction_factor);
 
   std::unordered_map<std::string, double> metrics_;
 
@@ -455,6 +455,7 @@ protected:
   std::string map_topic_{"map"};
   bool use_cluster_averaging_;
   bool use_augmented_mcl_;
+  bool dynamic_laser_importance_;
 };
 
 }  // namespace nav2_amcl

--- a/nav2_amcl/include/nav2_amcl/pf/pf.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/pf.hpp
@@ -71,6 +71,11 @@ typedef struct
 
   // Weight for this pose
   double weight;
+
+  // Weight for this pose, not influenced by the laser importance factor
+  // used for calculating running averages 
+  // as we want them to represent a real picture not the one skewed but importance factor
+  double raw_weight;
 } pf_sample_t;
 
 

--- a/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
+++ b/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
@@ -62,6 +62,14 @@ public:
    */
   void SetLaserPose(pf_vector_t & laser_pose);
 
+  /*
+  * @brief Set laser importance factor
+  * @param importance_factor Importance factor
+  */
+  void setLaserImportanceFactor(double importance_factor){
+    importance_factor_ = importance_factor; 
+  };
+
 protected:
   double z_hit_;
   double z_rand_;
@@ -168,7 +176,7 @@ private:
    * @brief Perform the update function
    * @param data Laser data to use
    * @param pf Particle filter to use
-   * @return if it was succesful
+   * @return total weight of the particle set
    */
   static double sensorFunction(LaserData * data, pf_sample_set_t * set);
 };
@@ -202,7 +210,7 @@ private:
    * @brief Perform the update function
    * @param data Laser data to use
    * @param pf Particle filter to use
-   * @return if it was succesful
+   * @return total weight of the particle set
    */
   static double sensorFunction(LaserData * data, pf_sample_set_t * set);
   bool do_beamskip_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1800,7 +1800,7 @@ AmclNode::initServices()
 void
 AmclNode::initDiagnostic()
 {
-  diagnostic_updater_->setHardwareID("none");
+  diagnostic_updater_->setHardwareID("amcl");
   diagnostic_updater_->add("AMCL Diagnostics", this, &AmclNode::amclDiagnostics);
 }
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1328,7 +1328,7 @@ AmclNode::initParameters()
   }
   if (max_particles_ < 0) {
     RCLCPP_WARN(
-      get_logger(), "You've set max_particles to be negtive,"
+      get_logger(), "You've set max_particles to be negative,"
       " this isn't allowed so it will be set to default value 2000.");
     max_particles_ = 2000;
   }

--- a/nav2_amcl/src/sensors/laser/beam_model.cpp
+++ b/nav2_amcl/src/sensors/laser/beam_model.cpp
@@ -111,7 +111,8 @@ BeamModel::sensorFunction(LaserData * data, pf_sample_set_t * set)
       p += pz * pz * pz;
     }
 
-    sample->weight *= pow(p, self->importance_factor_); // Accroding to Probabilistic Robotics, 6.3.4
+    sample->raw_weight *= p;
+    sample->weight *= pow(p, self->importance_factor_); // According to Probabilistic Robotics, 6.3.4
     total_weight += sample->weight;
   }
 

--- a/nav2_amcl/src/sensors/laser/likelihood_field_model.cpp
+++ b/nav2_amcl/src/sensors/laser/likelihood_field_model.cpp
@@ -125,7 +125,8 @@ LikelihoodFieldModel::sensorFunction(LaserData * data, pf_sample_set_t * set)
       p += pz * pz * pz;
     }
 
-    sample->weight *= pow(p, self->importance_factor_); // Accroding to Probabilistic Robotics, 6.3.4
+    sample->raw_weight *= p;
+    sample->weight *= pow(p, self->importance_factor_); // According to Probabilistic Robotics, 6.3.4
     total_weight += sample->weight;
   }
 


### PR DESCRIPTION
## Purpose
- Gradually decrease laser importance based on Augmented MCL score
- I also changed the PR template in the repo, because it overwrites the one we use and it is annoying.
- Added `cluster_count` as a metric to track

## Approach
1. Calculate Augmented MCL Score (aka localization metric). More on that [here](https://cmrobotics.sharepoint.com/:w:/r/sites/ProductDevelopment/Documents/Requirements%20%26%20Documentation/Localisation%20Implementation%20%26%20Validation%20Process.docx?d=w24411ed9524642a5973c8e0764235bf6&csf=1&web=1&e=3LVOhv) (section `Augmented MCL Score`)
2. Use Augmented MCL score as a factor to reduce current laser importance

## Disclaimers
 - There is a flag that enables/disables the feature and it is disabled now. 
 - Proving the effectiveness of the feature is the next step