### PR TITLE
BTB-115 SS-294 redefine inscribed_radius to be max width of robot

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/footprint.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/footprint.hpp
@@ -63,6 +63,16 @@ void calculateMinAndMaxDistances(
   double & min_dist, double & max_dist);
 
 /**
+ * @brief Calculate the max width of the footprint (sideways, along Y)
+ *
+ * @param footprint The footprint to examine
+ * @param max_dist_along_y Output parameter of the max width of the robot
+ */
+void calculateMaxAlongY(
+  const std::vector<geometry_msgs::msg::Point> & footprint,
+  double & max_dist_along_y);
+
+/**
  * @brief Convert Point32 to Point
  */
 geometry_msgs::msg::Point toPoint(geometry_msgs::msg::Point32 pt);

--- a/nav2_costmap_2d/src/footprint.cpp
+++ b/nav2_costmap_2d/src/footprint.cpp
@@ -70,6 +70,17 @@ void calculateMinAndMaxDistances(
   max_dist = std::max(max_dist, std::max(vertex_dist, edge_dist));
 }
 
+void calculateMaxAlongY(
+  const std::vector<geometry_msgs::msg::Point> & footprint,
+  double & max_dist_along_y)
+{
+  max_dist_along_y = std::numeric_limits<double>::min();
+
+  for (unsigned int i = 0; i < footprint.size(); ++i) {
+    max_dist_along_y = std::max(max_dist_along_y, std::fabs(footprint[i].y));
+  }
+}
+
 geometry_msgs::msg::Point32 toPoint32(geometry_msgs::msg::Point pt)
 {
   geometry_msgs::msg::Point32 point32;

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -273,6 +273,10 @@ void LayeredCostmap::setFootprint(const std::vector<geometry_msgs::msg::Point> &
     footprint_spec,
     inscribed_radius_, circumscribed_radius_);
 
+  nav2_costmap_2d::calculateMaxAlongY(
+    footprint_spec,
+    inscribed_radius_);
+
   for (vector<std::shared_ptr<Layer>>::iterator plugin = plugins_.begin();
     plugin != plugins_.end();
     ++plugin)


### PR DESCRIPTION
## Problem
Current definition of Inscribed radius (closest point along the footprint to the robot center) is not very meaningful for our robot shape since we never drive backwards. This causes global plan (A*) to underestimate possible collisions when planning, leading to **robot getting stuck** when it attempts to follow the seemingly collision-free global plan (as RPP then does a full SE2 collision check). This can be seen when robot attempts to navigates out from under the trolley or around tight spaces.

In other words, what the current definition of inscribed_radius (closest point) tells the planner is that there exists a pose that would not be in collision even when the robot is right up against an obstacle. It is basically a best-case scenario for a holonomic robot.

The image shows how inscribed radius (blue circle) is defined currently for the robot footprint (green):
![image](https://github.com/cmrobotics/navigation2/assets/18737820/bda3006a-a34f-49f2-b91e-e0ab0c3f80b5)


## Solution
Re-define `inscribed_radius_` to be the max width of the robot. _(trying not to change original nav2 code)_
