### PR TITLE
Robot getting stuck at a distance from goal

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -314,6 +314,7 @@ protected:
   bool allow_reversing_;
   double max_robot_pose_search_dist_;
   double max_extended_collision_check_dist_;
+  double extended_collision_check_path_end_leniency_;
   bool use_interpolation_;
 
   nav_msgs::msg::Path global_plan_;


### PR DESCRIPTION
## Problem 
Problem introduced by extended collision check feature (point-cost check along global plan upto a fixed distance)
Robot gets stuck at `extended_collision_check_distance` when approaching goal. A valid global plan in global costmap is collision-free but the final poses in the plan can be within inscribed radius inflation in local costmap because of a finer local costmap resolution, so RPP complains. 

The final pose or two in plan is inside a transparent light blue part (local costmap inscribed inflation). 
![Screenshot from 2023-08-02 13-45-36](https://github.com/cmrobotics/navigation2/assets/18737820/b19a90c1-bc4b-4fd6-92d1-621561a53c5b)

## Solution
When approaching goal, limit extended collision check