### PR TITLE
SS-331 SS-332 Don't throw exception if action/service unavailable while constructing BT

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -97,9 +97,6 @@ public:
       RCLCPP_ERROR(
         node_->get_logger(), "\"%s\" action server not available after waiting for 1 s",
         action_name.c_str());
-      throw std::runtime_error(
-              std::string("Action server ") + action_name +
-              std::string(" not available"));
     }
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -78,10 +78,6 @@ public:
       RCLCPP_ERROR(
         node_->get_logger(), "\"%s\" service server not available after waiting for 1 s",
         service_node_name.c_str());
-      throw std::runtime_error(
-              std::string(
-                "Service server %s not available",
-                service_node_name.c_str()));
     }
 
     RCLCPP_DEBUG(


### PR DESCRIPTION
Many servers are not available at the beginning. Do not wait for them just to construct the behavior tree. 