### PR TITLE
Differentiate between transform tolerances SS-102

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -440,7 +440,9 @@ protected:
   tf2::Duration save_pose_period_;
   double sigma_hit_;
   bool tf_broadcast_;
-  tf2::Duration transform_tolerance_;
+  tf2::Duration transform_tol_scan_odom_sec_;
+  tf2::Duration transform_tol_scan_robot_sec_;
+  tf2::Duration pose_valid_in_future_sec_;
   tf2::Duration transform_lookup_timeout_;
   double a_thresh_;
   double d_thresh_;


### PR DESCRIPTION
## Purpose
Differentiate between the time tolerances, laser to odom transform, laset to base_footprint transform and map to odom transform, these where all the same parameter before. This allows for each parameter to be changed individually. It was tested by starting the software stack and reading the new parameters.
[Jira](https://cm-robotics.atlassian.net/browse/SS-102)