### PR TITLE
Print currently used random seeds, SS-404

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -288,6 +288,11 @@ protected:
   pf_vector_t pf_odom_pose_;
   int resample_count_{0};
 
+  // Random seeds
+  long amcl_seed_;
+  long gaussian_pdf_seed_;
+  long pf_seed_;
+  
   // External pose fusion related
   /*
    * @brief Check if external pose has been received
@@ -308,9 +313,6 @@ protected:
   double std_warn_level_y_;
   double std_warn_level_yaw_;
   double aug_mcl_score_threshold_;
-
-  std::string localization_mode_ = "";
-  rclcpp::Time last_mode_switch_ts_;
 
   /*
     * @brief Check localization health

--- a/nav2_amcl/include/nav2_amcl/pf/pf.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/pf.hpp
@@ -151,6 +151,9 @@ typedef struct _pf_t
   int ext_pose_is_valid;
 
   double use_augmented_mcl;
+
+  long gaussian_random_seed;
+  long pf_random_seed;
 } pf_t;
 
 

--- a/nav2_amcl/include/nav2_amcl/pf/pf.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/pf.hpp
@@ -164,13 +164,13 @@ pf_t * pf_alloc(
   pf_init_model_fn_t random_pose_fn,
   void * random_pose_data,
   double max_particle_gen_prob_ext_pose,
-  int use_augmented_mcl);
+  int use_augmented_mcl, long pf_random_seed);
 
 // Free an existing filter
 void pf_free(pf_t * pf);
 
 // Initialize the filter using a guassian
-void pf_init(pf_t * pf, pf_vector_t mean, pf_matrix_t cov);
+void pf_init(pf_t * pf, pf_vector_t mean, pf_matrix_t cov, long gaussian_random_seed);
 
 // Initialize the filter using some model
 void pf_init_model(pf_t * pf, pf_init_model_fn_t init_fn, void * init_data);

--- a/nav2_amcl/include/nav2_amcl/pf/pf_pdf.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/pf_pdf.hpp
@@ -54,8 +54,8 @@ typedef struct
   pf_matrix_t cr;
   pf_vector_t cd;
 
-  // A random number generator
-  // gsl_rng *rng;
+  // Random seed
+  long seed;
 } pf_pdf_gaussian_t;
 
 

--- a/nav2_amcl/include/nav2_amcl/pf/pf_pdf.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/pf_pdf.hpp
@@ -60,7 +60,7 @@ typedef struct
 
 
 // Create a gaussian pdf
-pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx);
+pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx, long gaussian_random_seed);
 
 // Destroy the pdf
 void pf_pdf_gaussian_free(pf_pdf_gaussian_t * pdf);

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -290,8 +290,8 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
     "Use dynamic laser importance based on augmented MCL score"
   );
 
-  localization_mode_ = "laser";
-  last_mode_switch_ts_ = now();
+  amcl_seed_ = time(NULL);
+  srand48(amcl_seed_);
   
   diagnostic_updater_ = std::make_shared<diagnostic_updater::Updater>(this);
 }
@@ -775,6 +775,10 @@ AmclNode::handleInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped & msg)
   pf_init_ = false;
   init_pose_received_on_inactive = false;
   initial_pose_is_known_ = true;
+
+  RCLCPP_INFO(get_logger(), "AMCL random seed: %ld", amcl_seed_);
+  RCLCPP_INFO(get_logger(), "Gaussian PDF random seed: %ld", pf_->gaussian_random_seed);
+  RCLCPP_INFO(get_logger(), "PF random seed: %ld", pf_->pf_random_seed);
 }
 
 void

--- a/nav2_amcl/src/pf/pf.c
+++ b/nav2_amcl/src/pf/pf.c
@@ -58,8 +58,6 @@ pf_t * pf_alloc(
   pf_sample_set_t * set;
   pf_sample_t * sample;
 
-  srand48(time(NULL));
-
   pf = calloc(1, sizeof(pf_t));
 
   pf->random_pose_fn = random_pose_fn;
@@ -67,6 +65,9 @@ pf_t * pf_alloc(
 
   pf->min_samples = min_samples;
   pf->max_samples = max_samples;
+
+  pf->pf_random_seed = time(NULL);
+  srand48(pf->pf_random_seed);
 
   // Control parameters for the population size calculation.  [err] is
   // the max error between the true distribution and the estimated
@@ -169,6 +170,10 @@ void pf_init(pf_t * pf, pf_vector_t mean, pf_matrix_t cov)
 
   // set converged to 0
   pf_init_converged(pf);
+
+  // Update seeds
+  pf->gaussian_random_seed = pdf->seed;
+
 }
 
 

--- a/nav2_amcl/src/pf/pf.c
+++ b/nav2_amcl/src/pf/pf.c
@@ -51,7 +51,7 @@ pf_t * pf_alloc(
   pf_init_model_fn_t random_pose_fn,
   void * random_pose_data,
   double max_particle_gen_prob_ext_pose,
-  int use_augmented_mcl)
+  int use_augmented_mcl, long pf_random_seed)
 {
   int i, j;
   pf_t * pf;
@@ -66,7 +66,11 @@ pf_t * pf_alloc(
   pf->min_samples = min_samples;
   pf->max_samples = max_samples;
 
-  pf->pf_random_seed = time(NULL);
+  if(pf_random_seed == -1) {
+    pf->pf_random_seed = time(NULL);
+  } else {
+    pf->pf_random_seed = pf_random_seed;
+  }
   srand48(pf->pf_random_seed);
 
   // Control parameters for the population size calculation.  [err] is
@@ -135,7 +139,7 @@ void pf_free(pf_t * pf)
 }
 
 // Initialize the filter using a guassian
-void pf_init(pf_t * pf, pf_vector_t mean, pf_matrix_t cov)
+void pf_init(pf_t * pf, pf_vector_t mean, pf_matrix_t cov, long gaussian_random_seed)
 {
   int i;
   pf_sample_set_t * set;
@@ -149,7 +153,7 @@ void pf_init(pf_t * pf, pf_vector_t mean, pf_matrix_t cov)
 
   set->sample_count = pf->max_samples;
 
-  pdf = pf_pdf_gaussian_alloc(mean, cov);
+  pdf = pf_pdf_gaussian_alloc(mean, cov, gaussian_random_seed);
 
   // Compute the new sample poses
   for (i = 0; i < set->sample_count; i++) {

--- a/nav2_amcl/src/pf/pf_pdf.c
+++ b/nav2_amcl/src/pf/pf_pdf.c
@@ -45,7 +45,7 @@ static unsigned int pf_pdf_seed;
  *************************************************************************/
 
 // Create a gaussian pdf
-pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx)
+pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx, long gaussian_random_seed)
 {
   pf_matrix_t cd;
   pf_pdf_gaussian_t * pdf;
@@ -64,9 +64,12 @@ pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx)
   pdf->cd.v[2] = sqrt(cd.m[2][2]);
 
   // Initialize the random number generator
-  // pdf->rng = gsl_rng_alloc(gsl_rng_taus);
-  // gsl_rng_set(pdf->rng, ++pf_pdf_seed);
-  pdf->seed = ++pf_pdf_seed;
+  if (gaussian_random_seed == -1){
+    pdf->seed = ++pf_pdf_seed;
+  }
+  else {
+    pdf->seed = gaussian_random_seed;
+  }
   srand48(pdf->seed);
 
   return pdf;

--- a/nav2_amcl/src/pf/pf_pdf.c
+++ b/nav2_amcl/src/pf/pf_pdf.c
@@ -66,7 +66,8 @@ pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx)
   // Initialize the random number generator
   // pdf->rng = gsl_rng_alloc(gsl_rng_taus);
   // gsl_rng_set(pdf->rng, ++pf_pdf_seed);
-  srand48(++pf_pdf_seed);
+  pdf->seed = ++pf_pdf_seed;
+  srand48(pdf->seed);
 
   return pdf;
 }


### PR DESCRIPTION
## Purpose
Better AMCL reproducibility

## Approach
1. Print current seed values i.e. publish them to /rosout which means they will be recorded in rosbag
2. If the specific mislocalization case needs to be investigated, we check the seed values used during that amcl run and pass them as parameters when running amcl locally
