### PR TITLE
SS-410 lookup into past with tolerence when getCurrentPose

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -579,7 +579,8 @@ Costmap2DROS::getRobotPose(geometry_msgs::msg::PoseStamped & global_pose)
 {
   return nav2_util::getCurrentPose(
     global_pose, *tf_buffer_,
-    global_frame_, robot_base_frame_, transform_tolerance_);
+    global_frame_, robot_base_frame_, transform_tolerance_,
+    now() - rclcpp::Duration::from_seconds(transform_tolerance_));
 }
 
 bool


### PR DESCRIPTION
## Purpose
Fix collision checking may be done with outdated current pose

**Old behaviour**
Looks for lastest tf available in the buffer (which can be up to 10s old), if not block for  _transform_tolerence_ seconds.

**New behaviour**
look for tf in the past _transform_tolerence_ seconds (not 10s). If not available, block for _transform_tolerence_ seconds.
 