### PR TITLE
Service to suspend map-odom tf update (SS-380)

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -48,7 +48,7 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include "cmr_msgs/srv/get_status.hpp"
-#include "cmr_msgs/srv/set_amcl_tf_state.hpp"
+#include "cmr_msgs/srv/suspend_amcl_update.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -331,19 +331,19 @@ protected:
   std::chrono::seconds ext_pose_check_interval_;
   bool ext_pose_active_;
 
-  // AMCL tf state reset related
-  rclcpp::Service<cmr_msgs::srv::SetAmclTfState>::SharedPtr set_amcl_tf_state_srv_;
-  rclcpp::TimerBase::SharedPtr reset_tf_state_timer_;
-  bool is_tf_to_update_;
-  double tf_state_reset_timeout_;
+  // AMCL update suspend related
+  rclcpp::Service<cmr_msgs::srv::SuspendAmclUpdate>::SharedPtr suspend_amcl_update_srv_;
+  rclcpp::TimerBase::SharedPtr enable_amcl_update_timer_;
+  bool is_amcl_update_suspended_;
+  int amcl_update_suspension_timeout_;
   geometry_msgs::msg::TransformStamped suspended_tf_stamped_;
   
   /*
    * @brief Service callback for setting amcl tf state
    */
-  void setAmclTfStateCallback(
-    const std::shared_ptr<cmr_msgs::srv::SetAmclTfState::Request> request,
-    std::shared_ptr<cmr_msgs::srv::SetAmclTfState::Response> response);
+  void suspendAmclUpdateCallback(
+    const std::shared_ptr<cmr_msgs::srv::SuspendAmclUpdate::Request> request,
+    std::shared_ptr<cmr_msgs::srv::SuspendAmclUpdate::Response> response);
 
   // Laser scan related
   /*

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -334,7 +334,7 @@ protected:
   // AMCL update suspend related
   rclcpp::Service<cmr_msgs::srv::SuspendAmclUpdate>::SharedPtr suspend_amcl_update_srv_;
   rclcpp::TimerBase::SharedPtr enable_amcl_update_timer_;
-  bool is_amcl_update_suspended_;
+  bool is_amcl_update_suspended_{false};
   int amcl_update_suspension_timeout_;
   geometry_msgs::msg::TransformStamped suspended_tf_stamped_;
   

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -48,6 +48,7 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include "cmr_msgs/srv/get_status.hpp"
+#include "cmr_msgs/srv/set_amcl_tf_state.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -329,6 +330,20 @@ protected:
   rclcpp::Time last_ext_pose_received_ts_;
   std::chrono::seconds ext_pose_check_interval_;
   bool ext_pose_active_;
+
+  // AMCL tf state reset related
+  rclcpp::Service<cmr_msgs::srv::SetAmclTfState>::SharedPtr set_amcl_tf_state_srv_;
+  rclcpp::TimerBase::SharedPtr reset_tf_state_timer_;
+  bool is_tf_to_update_;
+  double tf_state_reset_timeout_;
+  geometry_msgs::msg::TransformStamped suspended_tf_stamped_;
+  
+  /*
+   * @brief Service callback for setting amcl tf state
+   */
+  void setAmclTfStateCallback(
+    const std::shared_ptr<cmr_msgs::srv::SetAmclTfState::Request> request,
+    std::shared_ptr<cmr_msgs::srv::SetAmclTfState::Response> response);
 
   // Laser scan related
   /*

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -302,10 +302,6 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
     "Seed value for random number generator used in the amcl node"
   );
   add_parameter(
-    "is_amcl_update_suspended", rclcpp::ParameterValue(false),
-    "Wheter to update the tf map-odom"
-  );
-  add_parameter(
     "amcl_update_suspension_timeout", rclcpp::ParameterValue(24),
     "Timeout to reactivete the tf map-odom update"
   );
@@ -1405,7 +1401,6 @@ AmclNode::initParameters()
   get_parameter("amcl_random_seed", amcl_seed_);
   get_parameter("gaussian_pdf_random_seed", gaussian_pdf_seed_);
   get_parameter("pf_random_seed", pf_seed_);
-  get_parameter("is_amcl_update_suspended", is_amcl_update_suspended_);
   get_parameter("amcl_update_suspension_timeout", amcl_update_suspension_timeout_);
     
   save_pose_period_ = tf2::durationFromSec(1.0 / save_pose_rate);


### PR DESCRIPTION
## Purpose
Being able to suspend map-odom tf update for some scenarios.

## Approach
- Dedicated service.
- We keep sending the "frozen" `tf` with updated `timestamp`.
- If a suspension is requested, a timer is started to automatically reactivate the update after a certain amount of time.

## Dependency

- [service message](https://github.com/cmrobotics/behaviour_trees/pull/128)
