### PR TITLE
Footprint update service, SS-417

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2_sensor_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(angles REQUIRED)
+find_package(cmr_msgs REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Eigen3 REQUIRED)
@@ -74,6 +75,7 @@ set(dependencies
   tf2_sensor_msgs
   visualization_msgs
   angles
+  cmr_msgs
 )
 
 ament_target_dependencies(nav2_costmap_2d_core

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -58,6 +58,7 @@
 #include "tf2_ros/transform_listener.h"
 #include "tf2/time.h"
 #include "tf2/transform_datatypes.h"
+#include "cmr_msgs/srv/update_footprint.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
@@ -285,6 +286,10 @@ public:
    * getUnpaddedRobotFootprint(). */
   void setRobotFootprintPolygon(const geometry_msgs::msg::Polygon::SharedPtr footprint);
 
+  void updateFootprintCallback(
+    const cmr_msgs::srv::UpdateFootprint::Request::SharedPtr request,
+    cmr_msgs::srv::UpdateFootprint::Response::SharedPtr response);
+
   std::shared_ptr<tf2_ros::Buffer> getTfBuffer() {return tf_buffer_;}
 
   /**
@@ -311,6 +316,8 @@ protected:
 
   rclcpp::Subscription<geometry_msgs::msg::Polygon>::SharedPtr footprint_sub_;
   rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_sub_;
+
+  rclcpp::Service<cmr_msgs::srv::UpdateFootprint>::SharedPtr update_footprint_service_;
 
   // Dedicated callback group and executor for tf timer_interface and message fillter
   rclcpp::CallbackGroup::SharedPtr callback_group_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -371,6 +371,7 @@ protected:
   bool rolling_window_{false};     ///< Whether to use a rolling window version of the costmap
   bool track_unknown_space_{false};
   double transform_tolerance_{0};  ///< The timeout before transform errors
+  std::mutex footprint_update_mutex_;
 
   // Derived parameters
   bool use_radius_{false};

--- a/nav2_costmap_2d/package.xml
+++ b/nav2_costmap_2d/package.xml
@@ -39,6 +39,7 @@
   <depend>tf2_sensor_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>angles</depend>
+  <depend>cmr_msgs</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -377,6 +377,7 @@ Costmap2DROS::getParameters()
 void
 Costmap2DROS::setRobotFootprint(const std::vector<geometry_msgs::msg::Point> & points)
 {
+  std::lock_guard<std::mutex> lock(footprint_update_mutex_);
   unpadded_footprint_ = points;
   padded_footprint_ = points;
   padFootprint(padded_footprint_, footprint_padding_);

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -397,8 +397,13 @@ Costmap2DROS::updateFootprintCallback(
 {
   auto fp = std::make_shared<geometry_msgs::msg::Polygon>();
   fp->points = request->footprint.points;
-  setRobotFootprintPolygon(fp);
-  response->success = true;
+  try {
+    setRobotFootprintPolygon(fp);
+    response->success = true;
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(get_logger(), "Failed to update footprint: %s", e.what());
+    response->success = false;
+  }
 }
 
 void


### PR DESCRIPTION
## Purpose
We want to be sure that the robot footprint is updated when we request that on BT side. 

## Approach
Currently, the only way to get the current footprint is to listen to `/<costmap_name>/published_footprint`. Implementing based on that was quite cumbersome so I am bringing a server for a footprint update

I'm not removing topic subscriber for footprint updates, just added a mutex to separate topic and service ways of setting a footprint
For that reason, I'm not changing rviz plugging for footprint update
