### PR TITLE
Fix external pose time matching

### DIFF
--- a/nav2_amcl/src/sensors/external_pose/external_pose.cpp
+++ b/nav2_amcl/src/sensors/external_pose/external_pose.cpp
@@ -19,10 +19,10 @@ ExternalPoseBuffer::addMeasurement(const ExternalPoseMeasument measurement)
 bool
 ExternalPoseBuffer::findClosestMeasurement(double query_time_sec, ExternalPoseMeasument& out_measurement) const
 {
-    uint32_t min_abs_diff = INT32_MAX;
+    double min_abs_diff = std::numeric_limits<double>::max();
     size_t min_diff_idx = 0;
     for(size_t i = 0; i < buffer_.size(); i++){
-        uint32_t abs_diff = std::abs(buffer_[i].time_sec - query_time_sec);
+        double abs_diff = std::abs(buffer_[i].time_sec - query_time_sec);
 
         if(abs_diff < min_abs_diff){
             min_abs_diff = abs_diff;


### PR DESCRIPTION
## Purpose
The diff between 2 timestamps was written to an integer which automatically converted it to the nearest int. Given that time diff is almost always below 1, our diffs were either 0 or 1, which broke the whole time matching flow.

## Approach
Use floating point to store time difference