### PR TITLE
SS-713 SS-640 Fix: RPP overshoots when rotating to head heading - Introduce proportional rotate to heading

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -316,6 +316,9 @@ protected:
   double max_extended_collision_check_dist_;
   double extended_collision_check_path_end_leniency_;
   bool use_interpolation_;
+  double rotate_to_heading_min_angular_vel_;
+  double goal_yaw_tol_;
+  double rotate_to_heading_proportional_gain_;
 
   nav_msgs::msg::Path global_plan_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -434,12 +434,17 @@ void RegulatedPurePursuitController::rotateToHeading(
     min_allowed_angular_vel, 
     rotate_to_heading_angular_vel_
   );
-  angular_vel = sign * target_angular_vel;
-
   const double & dt = control_duration_;
-  const double min_feasible_angular_speed = curr_speed.angular.z - max_angular_accel_ * dt;
-  const double max_feasible_angular_speed = curr_speed.angular.z + max_angular_accel_ * dt;
-  angular_vel = std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+  const double min_feasible_angular_speed = std::min(
+    std::fabs(curr_speed.angular.z) - max_angular_accel_ * dt,
+    target_angular_vel
+  );
+  const double max_feasible_angular_speed = std::min(
+    std::fabs(curr_speed.angular.z) + max_angular_accel_ * dt, 
+    rotate_to_heading_angular_vel_
+  );
+  angular_vel = std::clamp(target_angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+  angular_vel = sign * angular_vel;
 }
 
 geometry_msgs::msg::Point RegulatedPurePursuitController::circleSegmentIntersection(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -435,15 +435,11 @@ void RegulatedPurePursuitController::rotateToHeading(
     rotate_to_heading_angular_vel_
   );
   const double & dt = control_duration_;
-  const double min_feasible_angular_speed = std::min(
-    std::fabs(curr_speed.angular.z) - max_angular_accel_ * dt,
-    target_angular_vel
-  );
   const double max_feasible_angular_speed = std::min(
     std::fabs(curr_speed.angular.z) + max_angular_accel_ * dt, 
     rotate_to_heading_angular_vel_
   );
-  angular_vel = std::clamp(target_angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+  angular_vel = std::min(target_angular_vel, max_feasible_angular_speed);
   angular_vel = sign * angular_vel;
 }
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -222,6 +222,20 @@ void RegulatedPurePursuitController::configure(
     allow_reversing_ = false;
   }
 
+  if (rotate_to_heading_angular_vel_ < rotate_to_heading_min_angular_vel_) {
+    RCLCPP_WARN(
+      logger_, "Rotate to heading angular velocity cannot be lower than minimum. "
+      "Defaulting rotate to heading angular velocity to minimum.");
+    rotate_to_heading_angular_vel_ = rotate_to_heading_min_angular_vel_;
+  }
+
+  if (rotate_to_heading_proportional_gain_ < 0.0) {
+    RCLCPP_WARN(
+      logger_, "Rotate to heading proportional gain cannot be negative. "
+      "Defaulting to 1.0.");
+    rotate_to_heading_proportional_gain_ = 1.0;
+  }
+
   global_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
   carrot_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>("lookahead_point", 1);
   carrot_arc_pub_ = node->create_publisher<nav_msgs::msg::Path>("lookahead_collision_arc", 1);

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -425,7 +425,7 @@ void RegulatedPurePursuitController::rotateToHeading(
   const double sign = angle_to_path > 0.0 ? 1.0 : -1.0;
 
   double min_allowed_angular_vel = 0.0;
-  if(angle_to_path > goal_yaw_tol_){
+  if(std::fabs(angle_to_path) > goal_yaw_tol_){
     min_allowed_angular_vel = rotate_to_heading_min_angular_vel_;
   }
 


### PR DESCRIPTION
## Problem
The robot often overshoots when rotating to goal heading because RPP accelerates robot to `rotate_to_heading_angular_vel` but then abrubtly sends zero cmd_vel when xy goal tolerance is reached. We want a smooth stop at goal heading, especially with tight tolerances.

Another (arguably unrelated problem) is that RPP puts upper and lower bounds on angular velocity based on `max_angular_accel` and current speed of robot which comes from odometry through controller_server. This instantaneous speed from odom is typically extremely noisy.
As a result, the resulting cmd_vel is also very noisy and in fact violates and goes above `rotate_to_heading_angular_vel` (which is an upper limit on angular vel)

### Before change: Robot rotating to goal heading. abrubt `0` vel at the end
Simulation-
![sim robot without rpp proportional rotate to heading](https://github.com/cmrobotics/navigation2/assets/18737820/2ec200e7-1dca-42d1-8b69-7e98807b5f1a)

Real robot: In addition to the abrubt `0` vel in the end, velocity goes over `2.0` rad/s although `rotate_to_heading_angular_vel` is `0.7`
![robot without rpp proportional rotate to heading](https://github.com/cmrobotics/navigation2/assets/18737820/1c57bc5d-a598-43a9-8de8-ee79308d98cb)



## Solution
- Scale `rotate_to_heading_angular_vel` according to angular distance `angle_to_path`. So angular velocity tends to 0 as the robot comes closer to goal heading.
- Apply an upper acceleration limit just as it is, but remove deceleration limit to simplify the control law and have stable control, as the robot decelerates naturally due to the proportional control

### After:
Simulation:
![sim robot with rpp proportional rotate to heading and cap](https://github.com/cmrobotics/navigation2/assets/18737820/2a956c7e-c39a-4c24-8704-dafb2374ddbd)

Real robot:
![Screenshot from 2024-01-25 11-29-04](https://github.com/cmrobotics/navigation2/assets/18737820/96ec6c62-f5a5-4d7c-bbc8-8381c99bdaf5)


