### PR TITLE
Ss 697 extrapolation into past + small fix in rviz visualization

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -549,7 +549,8 @@ bool RegulatedPurePursuitController::isCollisionImminentExtendedSearch()
     [this](geometry_msgs::msg::PoseStamped & poseStamped) {
       // Modify Z For visualization in rviz so it is drawn between global plan and collision arc
       geometry_msgs::msg::PoseStamped transformed_pose;
-      poseStamped.header = global_plan_.header;
+      poseStamped.header.frame_id = global_plan_.header.frame_id;
+      poseStamped.header.stamp = clock_->now();
       transformPose(costmap_ros_->getGlobalFrameID(), poseStamped, transformed_pose);
       transformed_pose.pose.position.z = 0.005;
       return transformed_pose;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -557,7 +557,7 @@ bool RegulatedPurePursuitController::isCollisionImminentExtendedSearch()
     }
   );
   extended_collision_check_path.header.frame_id = costmap_ros_->getGlobalFrameID();
-  extended_collision_check_path.header.stamp = global_plan_.header.stamp ;
+  extended_collision_check_path.header.stamp = clock_->now();
   extended_collision_check_path_pub_->publish(extended_collision_check_path);
 
   unsigned int mx, my;


### PR DESCRIPTION
Cause of error:
- planning may only happen once, like in dropoff nav, 
- The plan may be a few seconds old eventually as the robot follows the plan
- Transformation of poses in the global plan into local_costmap frame (odom) **during extended collision checking** along global plan then starts to complain because it is trying to lookup transform at the time when the global plan was received, which may now be old.

Solution:
- Use current time to transform poses in global plan every time extended collision check is porformed
 