### PR TITLE
feat: Optionally wait for service and action server in bt node constructor

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -91,12 +91,17 @@ public:
     // Now that we have the ROS node to use, create the action client for this BT action
     action_client_ = rclcpp_action::create_client<ActionT>(node_, action_name, callback_group_);
 
-    // Make sure the server is actually there before continuing
-    RCLCPP_DEBUG(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
-    if (!action_client_->wait_for_action_server(1s)) {
-      RCLCPP_ERROR(
-        node_->get_logger(), "\"%s\" action server not available after waiting for 1 s",
-        action_name.c_str());
+    bool wait_for_server;
+    getInput("wait_for_server_on_creation", wait_for_server);
+    if (wait_for_server)
+    {
+      // Make sure the server is actually there before continuing
+      RCLCPP_DEBUG(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
+      if (!action_client_->wait_for_action_server(1s)) {
+        RCLCPP_ERROR(
+          node_->get_logger(), "\"%s\" action server not available after waiting for 1 s",
+          action_name.c_str());
+      }
     }
   }
 
@@ -110,7 +115,9 @@ public:
   {
     BT::PortsList basic = {
       BT::InputPort<std::string>("server_name", "Action server name"),
-      BT::InputPort<std::chrono::milliseconds>("server_timeout")
+      BT::InputPort<std::chrono::milliseconds>("server_timeout"),
+      BT::InputPort<bool>("wait_for_server_on_creation", true, 
+        "Wheather to wait for service to be available during construction of BT")
     };
     basic.insert(addition.begin(), addition.end());
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -70,14 +70,19 @@ public:
     // Make a request for the service without parameter
     request_ = std::make_shared<typename ServiceT::Request>();
 
-    // Make sure the server is actually there before continuing
-    RCLCPP_DEBUG(
-      node_->get_logger(), "Waiting for \"%s\" service",
-      service_name_.c_str());
-    if (!service_client_->wait_for_service(1s)) {
-      RCLCPP_ERROR(
-        node_->get_logger(), "\"%s\" service server not available after waiting for 1 s",
-        service_node_name.c_str());
+    bool wait_for_server;
+    getInput("wait_for_server_on_creation", wait_for_server);
+    if (wait_for_server)
+    {
+      // Make sure the server is actually there before continuing
+      RCLCPP_DEBUG(
+        node_->get_logger(), "Waiting for \"%s\" service",
+        service_name_.c_str());
+      if (!service_client_->wait_for_service(1s)) {
+        RCLCPP_ERROR(
+          node_->get_logger(), "\"%s\" service server not available after waiting for 1 s",
+          service_node_name.c_str());
+      }
     }
 
     RCLCPP_DEBUG(
@@ -101,7 +106,9 @@ public:
   {
     BT::PortsList basic = {
       BT::InputPort<std::string>("service_name", "please_set_service_name_in_BT_Node"),
-      BT::InputPort<std::chrono::milliseconds>("server_timeout")
+      BT::InputPort<std::chrono::milliseconds>("server_timeout"),
+      BT::InputPort<bool>("wait_for_server_on_creation", true, 
+        "Wheather to wait for service to be available during construction of BT")
     };
     basic.insert(addition.begin(), addition.end());
 


### PR DESCRIPTION
## Purpose
Some non-critical servers used by BT may not be available at launch. So skip `wait_for_service()` and `wait_for_action_server()` for service and action servers respectively based on a flag.
By default, if flag is not set, we wait for the servers in the constructor thereby preserving previous behaviour.