### PR TITLE
(SS-459) Force fiducial update

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -244,7 +244,7 @@ protected:
     std::shared_ptr<cmr_msgs::srv::GetStatus::Response> response);
 
   // Nomotion update control. Used to temporarily let amcl update samples even when no motion occurs
-  std::atomic<bool> force_update_{false};
+  std::atomic<bool> force_update_{true};
 
   // Odometry
   /*

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -244,7 +244,7 @@ protected:
     std::shared_ptr<cmr_msgs::srv::GetStatus::Response> response);
 
   // Nomotion update control. Used to temporarily let amcl update samples even when no motion occurs
-  std::atomic<bool> force_update_{true};
+  std::atomic<bool> force_update_{false};
 
   // Odometry
   /*

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -864,7 +864,6 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     if (lasers_update_[laser_index]) {
       motion_model_->odometryUpdate(pf_, pose, delta);
     }
-    force_update_ = false;
   }
 
   bool resampled = false;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -899,7 +899,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
         }
       } else {
         pf_->ext_pose_is_valid = 0;
-        RCLCPP_WARN(get_logger(), "No valid external pose");
+        RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "No valid external pose");
       }
 
       // TODO:

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -716,6 +716,7 @@ AmclNode::externalPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamp
     rclcpp::Time(msg.header.stamp).seconds());
 
   ext_pose_buffer_->addMeasurement(pose);
+  force_update_ = true;
 }
 
 void
@@ -864,6 +865,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     if (lasers_update_[laser_index]) {
       motion_model_->odometryUpdate(pf_, pose, delta);
     }
+    force_update_ = false;
   }
 
   bool resampled = false;


### PR DESCRIPTION
## Purpose
Now that fiducial detection is more accurate and robust, we decided to use it not for just first initialisation.

## Approach
- Keeping `force_update_` var to `true`;
- increase tolerance for external pose search (look [here](https://github.com/cmrobotics/serena_bringup/pull/213)).
- reduces number of particles resample to apply such change at a faster rate (look [here](https://github.com/cmrobotics/serena_bringup/pull/213)).

## Example
In the following video the robot is randomly localized, then reset to correct position thanks to fiducial.
 
[force-fiducial-update.webm](https://github.com/cmrobotics/navigation2/assets/112620880/b1ef7c19-e920-4957-969d-10dd9b971e35)


## Dependency
- [serena_bringup](https://github.com/cmrobotics/serena_bringup/pull/213)