### PR TITLE
Feat/spread laser samples

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -439,6 +439,7 @@ protected:
   std::string global_frame_id_;
   double lambda_short_;
   double laser_likelihood_max_dist_;
+  double min_laser_hit_sample_dist_;
   double laser_max_range_;
   double laser_min_range_;
   std::string sensor_model_type_;

--- a/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
+++ b/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
@@ -131,7 +131,8 @@ public:
    */
   BeamModel(
     double z_hit, double z_short, double z_max, double z_rand, double sigma_hit,
-    double lambda_short, double chi_outlier, size_t max_beams, map_t * map, double laser_importance_factor);
+    double lambda_short, double chi_outlier, size_t max_beams, map_t * map, double laser_importance_factor,
+    const double min_laser_hit_sample_dist);
 
   /*
    * @brief Run a sensor update on laser
@@ -161,7 +162,8 @@ public:
    */
   LikelihoodFieldModel(
     double z_hit, double z_rand, double sigma_hit, double max_occ_dist,
-    size_t max_beams, map_t * map, double laser_importance_factor);
+    size_t max_beams, map_t * map, double laser_importance_factor,
+    const double min_laser_hit_sample_dist);
 
   /*
    * @brief Run a sensor update on laser
@@ -179,6 +181,8 @@ private:
    * @return total weight of the particle set
    */
   static double sensorFunction(LaserData * data, pf_sample_set_t * set);
+
+  double min_laser_hit_sample_dist_sq_;
 };
 
 /*
@@ -195,7 +199,8 @@ public:
     double z_hit, double z_rand, double sigma_hit, double max_occ_dist,
     bool do_beamskip, double beam_skip_distance,
     double beam_skip_threshold, double beam_skip_error_threshold,
-    size_t max_beams, map_t * map, double laser_importance_factor);
+    size_t max_beams, map_t * map, double laser_importance_factor,
+    const double min_laser_hit_sample_dist);
 
   /*
    * @brief Run a sensor update on laser

--- a/nav2_amcl/src/sensors/laser/beam_model.cpp
+++ b/nav2_amcl/src/sensors/laser/beam_model.cpp
@@ -29,7 +29,8 @@ namespace nav2_amcl
 
 BeamModel::BeamModel(
   double z_hit, double z_short, double z_max, double z_rand, double sigma_hit,
-  double lambda_short, double chi_outlier, size_t max_beams, map_t * map, double importance_factor)
+  double lambda_short, double chi_outlier, size_t max_beams, map_t * map, double importance_factor,
+  const double /*min_laser_hit_sample_dist*/)
 : Laser(max_beams, map)
 {
   z_hit_ = z_hit;

--- a/nav2_amcl/src/sensors/laser/likelihood_field_model_prob.cpp
+++ b/nav2_amcl/src/sensors/laser/likelihood_field_model_prob.cpp
@@ -34,7 +34,8 @@ LikelihoodFieldModelProb::LikelihoodFieldModelProb(
   double beam_skip_distance,
   double beam_skip_threshold,
   double beam_skip_error_threshold,
-  size_t max_beams, map_t * map, double importance_factor)
+  size_t max_beams, map_t * map, double importance_factor,
+  const double /*min_laser_hit_sample_dist*/)
 : Laser(max_beams, map)
 {
   z_hit_ = z_hit;


### PR DESCRIPTION
## Problem
Nearby laser hits have a greater impact on the score of a particle simply because there happens to be more laser hits the closer the objects/walls for typical lidars. We want all walls/objects to have roughly the same impact on the score. 

## Approach
For each laser hit, check that it is at least `min_laser_hit_sample_dist` away from the previous laser hit, skip probability calculation otherwise.

This feature is disabled by default(by having `min_laser_hit_sample_dist` set to zero in params).

Currently implemented only for likelihood_field_model
