### PR TITLE
Fix behaviour tree construction fails

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_cancel_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_cancel_action_node.hpp
@@ -93,9 +93,6 @@ public:
       RCLCPP_ERROR(
         node_->get_logger(), "\"%s\" action server not available after waiting for 1 s",
         action_name.c_str());
-      throw std::runtime_error(
-              std::string("Action server ") + action_name +
-              std::string(" not available"));
     }
   }
 


### PR DESCRIPTION
Don't throw an exception if an action server (for cancellation) is not available during BT construction.
If the action server still isn't available when its actually needed (bt action node ticked), we handle that particular BT node failing with the specific context its in, but do not fail the entire thing at launch.