### PR TITLE
SS-814 Revert "add intial_pose_is_ready flag" - Fix: robot localized with rviz, but keeps doing initialization behaviour

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -409,12 +409,7 @@ protected:
    */
   void handleInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped & msg);
   bool init_pose_received_on_inactive{false};
-  
-  // Flag signaling that the initial pose has been set
   bool initial_pose_is_known_{false};
-
-  // Flag signaling that the initial pose has been received
-  bool initial_pose_is_ready_{false};
   bool set_initial_pose_{false};
   bool always_reset_initial_pose_;
   double initial_pose_x_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -623,7 +623,7 @@ AmclNode::getInitialPoseStatusCallback(
 {
   response->status = response->STATUS_NOT_READY;
 
-  if(initial_pose_is_ready_) response->status = response->STATUS_OK;
+  if(initial_pose_is_known_) response->status = response->STATUS_OK;
 }
 
 void
@@ -653,15 +653,13 @@ AmclNode::initialPoseReceived(geometry_msgs::msg::PoseWithCovarianceStamped::Sha
     // Overriding last published pose to initial pose
     last_published_pose_ = *msg;
 
-    if (!active_) {
-      init_pose_received_on_inactive = true;
-      RCLCPP_WARN(
-        get_logger(), "Received initial pose request, "
-        "but AMCL is not yet in the active state");
-      return;
-    }
-
-    initial_pose_is_ready_ = true;
+  if (!active_) {
+    init_pose_received_on_inactive = true;
+    RCLCPP_WARN(
+      get_logger(), "Received initial pose request, "
+      "but AMCL is not yet in the active state");
+    return;
+  }
   }
   
   handleInitialPose(*msg);


### PR DESCRIPTION
## Problem
If robot is localized very quickly with rviz at launch (before AMCL was activated), it appears to be localized on rviz, but BT continues to perform initial location behaviour (spinning in place).
This can also happen if it saw a fiducial only once, and then robot spun and the fiducial immediately went out of sight.

## Solution/Reason

This reverts commit 6d97e0e8ff87ae5d56dab61246cccf9de3bde19a, which introduces a new flag `initial_pose_is_ready_`, to use in place of the existing `initial_pose_is_known_`.

If an initial pose is received before activate, it is cached (through `last_published_pose_`) and used later when amcl is activated. This introduces a bug where the newly introduced `initial_pose_is_ready_` never gets set to True so the service call BT uses to check if robot is localized keeps returning false

`initial_pose_is_ready_` should have been set to true in places where the already existing `initial_pose_is_known_` is set. (inside `handleInitialPose()` and `globalLocalizationCallback()`)

`initial_pose_is_ready_` would then become identical to `initial_pose_is_known_`, with the only difference being that the new variable is set before `handleInitialPose()`. 

`handleInitialPose()` delays setting it to true due to a lookuptransform inside - so the introduction of the new variable this was seemingly done for a minor time optimization as lookup transform takes time (100ms?). **However** this doesn't actually work because service calls and initial pose callback are on the same (main)executor anyway, which means while an initial pose is being processed, initialPoseStatus service calls get queued and wont respond until `handleInitialPose() completes`.

Note: AMCL has only two threads:
- laser callback + the TF buffer on one Mutually exclusive cb group.
- Everything else - lifecycle, services, dynamic parameter, odom, initial, external pose callbacks, particle filter

Related PR - 
- https://github.com/cmrobotics/navigation2/pull/45