### PR TITLE
SS-1354 RPP tight curves when carrot point behind

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -319,6 +319,7 @@ protected:
   double rotate_to_heading_min_angular_vel_;
   double goal_yaw_tol_;
   double rotate_to_heading_proportional_gain_;
+  bool forward_only_carrot_;
 
   nav_msgs::msg::Path global_plan_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -130,6 +130,10 @@ void RegulatedPurePursuitController::configure(
     node, plugin_name_ + ".rotate_to_heading_proportional_gain",
     rclcpp::ParameterValue(10.0));
 
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".forward_only_carrot",
+    rclcpp::ParameterValue(false));
+
   node->get_parameter(plugin_name_ + ".desired_linear_vel", desired_linear_vel_);
   base_desired_linear_vel_ = desired_linear_vel_;
   node->get_parameter(plugin_name_ + ".lookahead_dist", lookahead_dist_);
@@ -201,6 +205,9 @@ void RegulatedPurePursuitController::configure(
   node->get_parameter(
     plugin_name_ + ".rotate_to_heading_proportional_gain",
     rotate_to_heading_proportional_gain_);
+  node->get_parameter(
+    plugin_name_ + ".forward_only_carrot",
+    forward_only_carrot_);
 
   transform_tolerance_ = tf2::durationFromSec(transform_tolerance);
   control_duration_ = 1.0 / control_frequency;
@@ -354,6 +361,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   }
 
   auto carrot_pose = getLookAheadPoint(lookahead_dist, transformed_plan);
+
   carrot_pub_->publish(createCarrotMsg(carrot_pose));
 
   double linear_vel, angular_vel;
@@ -496,6 +504,7 @@ geometry_msgs::msg::PoseStamped RegulatedPurePursuitController::getLookAheadPoin
   const double & lookahead_dist,
   const nav_msgs::msg::Path & transformed_plan)
 {
+  geometry_msgs::msg::PoseStamped carrot_pose;
   // Find the first pose which is at a distance greater than the lookahead distance
   auto goal_pose_it = std::find_if(
     transformed_plan.poses.begin(), transformed_plan.poses.end(), [&](const auto & ps) {
@@ -504,7 +513,7 @@ geometry_msgs::msg::PoseStamped RegulatedPurePursuitController::getLookAheadPoin
 
   // If the no pose is not far enough, take the last pose
   if (goal_pose_it == transformed_plan.poses.end()) {
-    goal_pose_it = std::prev(transformed_plan.poses.end());
+    carrot_pose = *std::prev(transformed_plan.poses.end());
   } else if (use_interpolation_ && goal_pose_it != transformed_plan.poses.begin()) {
     // Find the point on the line segment between the two poses
     // that is exactly the lookahead distance away from the robot pose (the origin)
@@ -519,10 +528,19 @@ geometry_msgs::msg::PoseStamped RegulatedPurePursuitController::getLookAheadPoin
     pose.header.frame_id = prev_pose_it->header.frame_id;
     pose.header.stamp = goal_pose_it->header.stamp;
     pose.pose.position = point;
-    return pose;
+    carrot_pose = pose;
+  } else {
+    carrot_pose = *goal_pose_it;
   }
 
-  return *goal_pose_it;
+  if (forward_only_carrot_ && carrot_pose.pose.position.x < 0) {
+    carrot_pose.pose.position.x = 0;
+    if (std::abs(carrot_pose.pose.position.y) < min_lookahead_dist_) {
+      carrot_pose.pose.position.y = std::copysign(min_lookahead_dist_, carrot_pose.pose.position.y);
+    }
+  }
+
+  return carrot_pose;
 }
 
 bool RegulatedPurePursuitController::isCollisionImminentExtendedSearch()

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -715,6 +715,43 @@ TEST(RegulatedPurePursuitTest, extended_collision_check)
   ctrl->cleanup();
 }
 
+
+TEST(RegulatedPurePursuitTest, carrot_point_not_behind)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("testRPPcarrot_point_not_behind");
+  std::string plugin_name = "PathFollower";
+  auto ctrl = std::make_shared<BasicAPIRPP>();
+  auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
+  rclcpp_lifecycle::State state;
+  costmap->on_configure(state);
+  ctrl->configure(node, plugin_name, tf, costmap);
+
+  const double min_lookahead_dist = 0.3;
+  node->set_parameter(
+    rclcpp::Parameter(
+      plugin_name + ".forward_only_carrot",
+      rclcpp::ParameterValue(true)));
+  node->set_parameter(
+    rclcpp::Parameter(
+      plugin_name + ".min_lookahead_dist",
+      rclcpp::ParameterValue(min_lookahead_dist)));
+  ctrl->configure(node, plugin_name, tf, costmap);
+
+  nav_msgs::msg::Path global_plan_in_base_frame;
+  global_plan_in_base_frame.poses.resize(5);
+  for (uint i = 0; i < global_plan_in_base_frame.poses.size(); i++) {
+    global_plan_in_base_frame.poses[i].pose.position.x = -static_cast<double>(i);  // Backwards
+  }
+
+  const double lookahead_dist = 0.5;
+  const auto pt = ctrl->getLookAheadPointWrapper(lookahead_dist, global_plan_in_base_frame);
+
+  // Carrot must be beside, not behind
+  EXPECT_GE(pt.pose.position.x, 0.0);
+  EXPECT_GE(pt.pose.position.y, min_lookahead_dist);
+}
+
 TEST(RegulatedPurePursuitTest, extended_collision_check_transform_check)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("testRPP");


### PR DESCRIPTION
## Purpose
When reversing and rotate in place are not allowed, and global plan ends up behind the robot, the carrot point also lies behind, which produces motion with large curvatures.

## Solution
Restrict location of the carrot point so it is either in front of at most beside the robot with the minimum lookahead distance, never in front (trolley nav only).

Before:
[carrot behind.webm](https://github.com/user-attachments/assets/9a149631-764e-479c-9a96-fc7f2116b9a6)

After:
[carrot in front.webm](https://github.com/user-attachments/assets/97a456fe-dde8-4fe2-9f5b-d3410b23b9c3)

